### PR TITLE
POSIX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This can be overridden by the config variables `BUILD_CMD=rebar|mix`, `RELEASE_C
 
 Edeliver uses ssh and scp to build and deploy the releases.  It is recommended that you use ssh and scp with key+passphrase only.  You can use `ssh-add` if you don't want to enter your passphrase every time.
 
-It may be required to install and configure git on your build host. You may also have to clone the repository initially at the `BUILD_AT` path, although edeliver will try to take care of this for you. [Erlang](http://www.erlang.org/) and [Elixir](http://elixir-lang.org/) must be installed and available on the `BUILD_HOST`. The default shell for the build and deploy user should be `bash` or `zsh` on your build and deployment systems (check that especially if you are [running FreeBSD](https://www.freebsd.org/doc/en/articles/linux-users/shells.html)).
+It may be required to install and configure git on your build host. You may also have to clone the repository initially at the `BUILD_AT` path, although edeliver will try to take care of this for you. [Erlang](http://www.erlang.org/) and [Elixir](http://elixir-lang.org/) must be installed and available on the `BUILD_HOST`. The default shell for the build user should be `bash` or `zsh` on your build host (usually already the default on most systems).
 
 The build host must be similar to the production/staging hosts.  For example, if you want to deploy to a production system based on Linux, the release must also be built on a Linux system.
 

--- a/libexec/common
+++ b/libexec/common
@@ -131,6 +131,20 @@ init_app_remotely() {
     fi
   done
   __sync_remote "
+    current_shell=\"\$0\" || :
+    [ -z \"\$current_shell\" ] && current_shell=\"\$SHELL\"
+    case \"\$current_shell\" in
+      (*bash*) echo 'bash is installed and the default shell' $SILENCE ;;
+      (*zsh*)  echo  'zsh is installed and the default shell' $SILENCE ;;
+      (*)
+       echo
+       echo \"${txtred}You are using an unsupported shell: '\$current_shell'\"
+       echo \"edeliver requires either bash or zsh to be installed\"
+       echo \"and the default shell for the build user '$BUILD_USER'\"
+       echo \"on your build host: '$BUILD_HOST'.${txtrst}\"
+       exit 1
+       ;;
+    esac
     set -e
     if [ ! -d $DELIVER_TO ]
     then

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -697,25 +697,25 @@ upload_release_archive() {
   if [ "$RELEASE_STORE_TYPE" = "s3" ]; then
     local _aws_script_content=$(cat $BASE_PATH/libexec/aws)
     __remote "
-      [ -f ~/.profile ] && source ~/.profile
+      [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
       set -e
-      mkdir -p ${_destination_directory} $SILENCE
-      cd ${_destination_directory} $SILENCE
+      mkdir -p \"${_destination_directory}\" $SILENCE
+      cd \"${_destination_directory}\" $SILENCE
       AWS_ARGUMENTS=\"get ${AWS_BUCKET_NAME}/${_release_file} \" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl > ${APP}_${_release_version}.tar.gz 2>/dev/null <<'EOF'${_aws_script_content}EOF ;" "$HOSTS_APP_USER" "
 
-      [ -f ~/.profile ] && source ~/.profile
+      [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
       set -e
-      mkdir -p ${_destination_directory} $SILENCE
-      cd ${_destination_directory} $SILENCE
+      mkdir -p \"${_destination_directory}\" $SILENCE
+      cd \"${_destination_directory}\" $SILENCE
       AWS_ARGUMENTS=\"get ${AWS_BUCKET_NAME}/${_release_file} \" AWS_ACCESS_KEY_ID=\"$AWS_ACCESS_KEY_ID\" \\
       AWS_SECRET_ACCESS_KEY=\"$AWS_SECRET_ACCESS_KEY\" perl > ${APP}_${_release_version}.tar.gz 2>/dev/null <<'EOF'
         content from libexec/aws file
       EOF ;"
   elif [ "$RELEASE_STORE_TYPE" = "local" ]; then
     __remote "
-      [ -f ~/.profile ] && source ~/.profile
+      [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
       set -e
-      mkdir -p ${_destination_directory} "
+      mkdir -p \"${_destination_directory}\" "
     __parallel_scp "${RELEASE_STORE}/releases/${_release_file}" "${_destination_directory}/${APP}_${_release_version}.tar.gz"
   elif [ "$RELEASE_STORE_TYPE" = "remote" ]; then
     local _release_store_path=${RELEASE_STORE#*:}
@@ -724,16 +724,16 @@ upload_release_archive() {
     local _dest_file_name="${_destination_directory}/${APP}_${_release_version}.tar.gz"
 
     local _remote_job="
-      [ -f ~/.profile ] && source ~/.profile
+      [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
       set -e
-      cd $_release_store_path
-      [ -f \"$_release_file\" ]
+      cd \"$_release_store_path\"
+      [ -f \"$_release_file\" ] || exit 1
       background_jobs_pids=()
       background_jobs=()
     "
     for _host in $_deploy_hosts; do
       _remote_job="$_remote_job
-        if [[ \"$_host\" = \"$_release_store_host\" ]]; then
+        if [ \"$_host\" = \"$_release_store_host\" ]; then
           mkdir -p \"${_destination_directory}\"
           cp $_release_file $_dest_file_name &
         else
@@ -766,9 +766,9 @@ upgrade_release() {
   [[ "$RELEASE_CMD" = "mix" ]] && local _upgrade_command="bin/${APP} upgrade ${VERSION} $SILENCE" \
                                || local _upgrade_command="bin/${APP} upgrade ${APP}_${VERSION} $SILENCE"
   __remote "
-    [ -f ~/.profile ] && source ~/.profile
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    cd ${DELIVER_TO}/${APP} $SILENCE
+    cd \"${DELIVER_TO}/${APP}\" $SILENCE
     $_upgrade_command
   "
   __exec_if_defined "post_upgrade_release"
@@ -782,20 +782,20 @@ remote_clean_release_dir() {
   local _archive="${APP}_${_release_version}.tar.gz"
   status "Cleaning release directory"
   __remote "
-    [ -f ~/.profile ] && source ~/.profile
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    cd ${_archive_dir} $SILENCE
-    [[ \"$RELEASE_CMD\" = \"mix\" ]] && _app_folder=\"${APP}\" || _app_folder=\$(dirname \$(dirname \$(tar -tzf ${_archive} | grep releases/RELEASES)))
-    [[ -n \"\$_app_folder\" ]]
-    if [[ -d \$_app_folder ]]; then
-      cd \${_app_folder}
-      if [[ -d releases ]]; then
+    cd \"${_archive_dir}\" $SILENCE
+    [ \"$RELEASE_CMD\" = \"mix\" ] && _app_folder=\"${APP}\" || _app_folder=\$(dirname \$(dirname \$(tar -tzf ${_archive} | grep releases/RELEASES)))
+    [ -n \"\$_app_folder\" ] || exit 1
+    if [ -d \"\$_app_folder\" ]; then
+      cd \"\${_app_folder}\"
+      if [ -d releases ]; then
         echo \"deleting releases dir in \${_app_folder}\" $SILENCE
         rm -rf releases $SILENCE
       else
         echo \"releases dir already deleted in \${_app_folder}\" $SILENCE
       fi
-      if [[ -d lib ]]; then
+      if [ -d lib ]; then
         echo \"deleting lib dir in \${_app_folder}\" $SILENCE
         rm -rf lib $SILENCE
       else
@@ -803,9 +803,9 @@ remote_clean_release_dir() {
       fi
       ls -al | grep erts- > /dev/null && {
         for erts_dir in erts-*; do
-          if [[ -n \"\$erts_dir\" ]] && [[ -d \$erts_dir ]]; then
+          if [ -n \"\$erts_dir\" ] && [ -d \"\$erts_dir\" ]; then
             echo \"deleting \${erts_dir} in \${_app_folder}\" $SILENCE
-            rm -rf \${erts_dir} $SILENCE
+            rm -rf \"\${erts_dir}\" $SILENCE
           else
             echo \"erts dir already deleted in \${_app_folder}\" $SILENCE
           fi
@@ -837,7 +837,7 @@ __get_node_command() {
   echo "
     [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    cd ${_app_path}/${APP} $SILENCE
+    cd \"${_app_path}/${APP}\" $SILENCE
     output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
     if [ \"\$output_lines\" -gt 1 ]; then
       output_filter_command='tail'
@@ -907,10 +907,10 @@ remote_extract_release_archive() {
   # when building releses with mix, the tar does not contain the app name as subdirectory
   [[ "$RELEASE_CMD" = "mix" ]] && _archive_dir="${_archive_dir%%/}/${APP}"
   __remote "
-    [ -f ~/.profile ] && source ~/.profile
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    cd ${_archive_dir} $SILENCE
-    tar -xzvf ${_archive} $SILENCE && rm ${_archive} $SILENCE"
+    cd \"${_archive_dir}\" $SILENCE
+    tar -xzvf \"${_archive}\" $SILENCE && rm \"${_archive}\" $SILENCE"
   __exec_if_defined "post_extract_release_archive"
 }
 

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -832,12 +832,14 @@ __get_node_command() {
     local _rpc_open_brackets="[["
     local _rpc_close_brackets="]]"
   fi
+  [[ "${_node_command}" = start* ]] && local _is_start_command="true" || :
+  [[ "${_node_command}" = restart* ]] && local _is_restart_command="true" || :
   echo "
-    [ -f ~/.profile ] && source ~/.profile
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
     cd ${_app_path}/${APP} $SILENCE
     output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
-    if [[ \"\$output_lines\" -gt 1 ]]; then
+    if [ \"\$output_lines\" -gt 1 ]; then
       output_filter_command='tail'
       output_filter_command_options=\"-n+\$output_lines\"
     else
@@ -850,31 +852,31 @@ __get_node_command() {
     __edeliver_synchronous_start() {
       bin/${APP} start | \$output_filter_command \$output_filter_command_options
       sleep 1
-      for i in {1..10}; do
+      for i in 1 2 3 4 5 6 7 8 9 10; do
         __edeliver_node_running && break || :
         sleep 1
       done
       bin/${APP} ${_rpc_command} Elixir.Edeliver run_command '${_rpc_open_brackets}monitor_startup_progress, \"$APP\", $MODE${_rpc_close_brackets}.' | \$output_filter_command \$output_filter_command_options | grep -e 'Started\\|^ok' || :
     }
-    if [[ \"$RELEASE_CMD\" = \"mix\" && \"${_node_command}\" = start* ]]; then
-      ping_result=\$(bin/${APP} ping | \$output_filter_command \$output_filter_command_options || :)
+    if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$_is_start_command\" = \"true\" ]; then
+      ping_result=\"\$(bin/${APP} ping | \$output_filter_command \$output_filter_command_options || :)\"
       if __edeliver_node_running; then
         echo \"${txtred}already running${txtrst}\" && exit 1
       else
         __edeliver_synchronous_start
       fi
-    elif [[ \"${_node_command}\" = restart* ]]; then
+    elif [ \"$_is_restart_command\" = \"true\" ]; then
       # use stop / start instead of restart command to
       # not just restart the applications but also the erlang vm
       # with the most recent release
       if __edeliver_node_running; then
-        STOP_OUTPUT=\$(${_node_env}bin/${APP} stop ${_config_arg} | \$output_filter_command \$output_filter_command_options)
-        if [[ \$? -ne 0 ]]; then
+        STOP_OUTPUT=\"\$(${_node_env}bin/${APP} stop ${_config_arg} | \$output_filter_command \$output_filter_command_options)\"
+        if [ \"\$?\" -ne 0 ]; then
           cat \"\$STOP_OUTPUT\"
           exit 1
         fi
       fi
-      if [[ \"$RELEASE_CMD\" = \"mix\" ]]; then
+      if [ \"$RELEASE_CMD\" = \"mix\" ]; then
         __edeliver_synchronous_start
       else
         ${_node_env}bin/${APP} start ${_config_arg} > >(\$output_filter_command \$output_filter_command_options)

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -480,7 +480,7 @@ done
 case "${MODE}" in
   (compact)
     VERBOSE=""
-    SILENCE="&> /dev/null"
+    SILENCE="> /dev/null"
   ;;
   (verbose)
     VERBOSE=true

--- a/strategies/erlang-deploy-upgrade
+++ b/strategies/erlang-deploy-upgrade
@@ -33,9 +33,9 @@ run() {
   if [[ "$RELEASE_CMD" = "mix" ]]; then
     upload_release_archive "${DELIVER_TO}/${APP}/releases/${VERSION}"
     __remote "
-      [ -f ~/.profile ] && source ~/.profile
+      [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
       set -e
-      cd ${DELIVER_TO}/${APP}/releases/${VERSION} $SILENCE
+      cd \"${DELIVER_TO}/${APP}/releases/${VERSION}\" $SILENCE
       mv \"${APP}_${VERSION}.tar.gz\" \"${APP}.tar.gz\"
     "
   else

--- a/strategies/erlang-update
+++ b/strategies/erlang-update
@@ -134,9 +134,9 @@ __execute_on_deploy_host() {
   local _command="$2"
 
   ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    [ -f ~/.profile ] && source ~/.profile
-    cd $DELIVER_TO/$APP $SILENCE
+    cd \"$DELIVER_TO/$APP\" $SILENCE
     $_command"
 }
 

--- a/strategies/erlang-update
+++ b/strategies/erlang-update
@@ -146,7 +146,8 @@ __execute_on_deploy_host() {
 # and returns 1 if node is offline.
 __is_node_offline() {
   local _deploy_host="$1"
-  [[ "pong" != "$(__execute_on_deploy_host "$_deploy_host" "bin/$APP ping" | tail -1)" ]]
+  local _node_command="$(__get_node_command "ping" "$DELIVER_TO" "")"
+  [[ "pong" != "$(__execute_on_deploy_host "$_deploy_host" "$_node_command")" ]]
 }
 
 # prints the currently running release version

--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -214,9 +214,9 @@ __execute_on_deploy_host() {
   local _command="$2"
 
   ssh -o ConnectTimeout="$SSH_TIMEOUT" "$_host" "
+    [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
-    [ -f ~/.profile ] && source ~/.profile
-    cd $DELIVER_TO/$APP $SILENCE
+    cd \"$DELIVER_TO/$APP\" $SILENCE
     $_command"
 }
 


### PR DESCRIPTION
Make all shell scripts on deploy hosts POSIX compatible. This allows to use there any shell as default shell (instead of requiring bash or zsh). Closes #143.
