### PR TITLE
Call Elixir.Edeliver.release_version directly when using rpcterms.

### DIFF
--- a/strategies/erlang-node-execute
+++ b/strategies/erlang-node-execute
@@ -74,7 +74,11 @@ run() {
   fi
 
   if [[ "$NODE_ACTION" = version ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
-    NODE_ACTION="${_rpc_command} Elixir.Edeliver run_command '${_rpc_open_brackets}release_version, \"$APP\"${_rpc_close_brackets}.' | tr -d \\\""
+    if [[ "$USING_DISTILLERY" = "true" ]]; then
+      NODE_ACTION="rpcterms Elixir.Edeliver release_version '$APP.' | tr -d \\\""
+    else
+      NODE_ACTION="${_rpc_command} Elixir.Edeliver run_command '${_rpc_open_brackets}release_version, \"$APP\"${_rpc_close_brackets}.' | tr -d \\\""
+    fi
   elif [[ "$NODE_ACTION" = ping ]] && [[ "$RELEASE_CMD" = "mix" ]]; then
     NODE_ACTION="ping"
   elif [[ "$NODE_ACTION" = migrations ]] && [[ "$RELEASE_CMD" = "mix" ]]; then

--- a/strategies/erlang-update
+++ b/strategies/erlang-update
@@ -154,7 +154,7 @@ __is_node_offline() {
 __get_installed_version_on_host() {
  local _deploy_host="$1"
  if [[ "$USING_DISTILLERY" = "true" ]]; then
-   __execute_on_deploy_host "$_deploy_host" "2>&1 bin/$APP rpcterms Elixir.Edeliver run_command '[release_version, \"$APP\"].' | tail -1 | tr -d \\\""
+   __execute_on_deploy_host "$_deploy_host" "2>&1 bin/$APP rpcterms Elixir.Edeliver release_version '$APP.' | tail -1 | tr -d \\\""
  else
    __execute_on_deploy_host "$_deploy_host" "2>&1 bin/$APP rpc Elixir.Edeliver run_command '[[release_version, \"$APP\"]].' | tail -1 | tr -d \\\""
  fi

--- a/strategies/erlang-upgrade
+++ b/strategies/erlang-upgrade
@@ -235,7 +235,7 @@ __is_node_offline() {
 __get_installed_version_on_host() {
  local _deploy_host="$1"
  if [[ "$USING_DISTILLERY" = "true" ]]; then
-   local _node_command="$(__get_node_command "rpcterms Elixir.Edeliver run_command '[release_version, \"$APP\"].' | tr -d \\\"" "$DELIVER_TO" "")"
+   local _node_command="$(__get_node_command "rpcterms Elixir.Edeliver release_version '$APP.' | tr -d \\\"" "$DELIVER_TO" "")"
  else
    local _node_command="$(__get_node_command "rpc Elixir.Edeliver run_command '[[release_version, \"$APP\"]].' | tr -d \\\"" "$DELIVER_TO" "")"
  fi


### PR DESCRIPTION
Why:

* Elixir.Edeliver.run_command doesn't work with umbrella apps.

This change addresses the need by:

* Call the release_version function directly with an erlang atom expression.