### PR TITLE
Updates to distillery integration

### DIFF
--- a/docs/relup-patching.md
+++ b/docs/relup-patching.md
@@ -49,6 +49,18 @@ behaviour and implement the `run/1` function.
 
 If you think the custom instruction might be useful also for other applications, feel free to submit a pull request.
 
+#### Integration with Distillery
+
+In order for your modifications to be applied, you have to configure Distillery to use edeliver's `Releases.Plugin.ModifyRelup` plugin.
+You can configure this in the `rel/config.exs` file like this:
+
+```elixir
+environment :prod do
+  ..
+  plugin Releases.Plugin.ModifyRelup
+end
+```
+
 #### Example
 
 This example shows a custom (runnable) instruction which would execute pending ecto migrations during the upgrade.
@@ -70,7 +82,7 @@ defmodule MyApp.Relup.MigrationInstruction do
 
   @doc "pass application name and version to the `run/1` function when executing the relup"
   def arguments(_instructions = %Instructions{up_version: up_version}, _config = %{name: name}) do
-    {name |> String.to_atom, up_version}
+    {name, up_version}
   end
 
   @doc "runs during upgrade"

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -1,6 +1,6 @@
 defmodule Releases.Plugin.LinkConfig do
   @moduledoc """
-    Exrm plugin to link the `vm.args` or `sys.config` file on deploy hosts.
+    Distillery plugin to link the `vm.args` or `sys.config` file on deploy hosts.
 
     Because distillery uses `:systools_make.make_tar(...)` to create the release
     tar which resoves all links using the `:dereference` option, the release

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -1,6 +1,16 @@
 defmodule Releases.Plugin.ModifyRelup do
   @moduledoc """
-    Exrm plugin to auto-patch the relup file when building upgrades.
+    Distillery plugin to auto-patch the relup file when building upgrades.
+
+    To be able use this plugin, it must be added in the `rel/config.exs`
+    distillery config as plugin like this:
+
+    ```
+    environment :prod do
+      ..
+      plugin Releases.Plugin.ModifyRelup
+    end
+    ```
   """
   use Mix.Releases.Plugin
   alias Edeliver.Relup.Instructions

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -7,7 +7,7 @@ defmodule Releases.Plugin.ModifyRelup do
 
   def before_assembly(_), do: nil
 
-  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, output_dir: output_dir}) do
+  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Mix.Releases.Profile{output_dir: output_dir}}) do
     case System.get_env "SKIP_RELUP_MODIFICATIONS" do
       "true" -> nil
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -54,11 +54,14 @@ defmodule Edeliver.Mixfile do
   ]
 
   defp elixirc_paths do
-
-    if project_uses_distillery?() do
-      [Path.join("lib", "distillery")]
-    else
-      [Path.join("lib", "exrm")]
+    cond do
+      System.get_env("PUBLISHING_TO_HEX_PM") == "true" ->
+        [
+          Path.join("lib", "distillery"),
+          Path.join("lib", "exrm")
+        ]
+      project_uses_distillery?() -> [Path.join("lib", "distillery")]
+      true -> [Path.join("lib", "exrm")]
     end ++ [
       Path.join("lib", "edeliver"),
       Path.join("lib", "mix"),
@@ -87,24 +90,20 @@ defmodule Edeliver.Mixfile do
         uses_distillery? -> true
         uses_exrm? -> false
         true ->
-          case System.get_env("PUBLISHING_TO_HEX_PM") do
-            "true" -> false
-            _ ->
-              Mix.Shell.IO.error "Failed to detect whether :distillery or :exrm is used as dependency.\n"
-                              <> "If you used exrm before (default), please add it to your mix.exs\n"
-                              <> "config file like this:\n\n"
-                              <> "defp deps do\n"
-                              <> "  [\n"
-                              <> "   ...\n"
-                              <> "   {:exrm, \">= 0.16.0\", warn_missing: false},\n"
-                              <> "  ]\n"
-                              <> "end\n\n"
-                              <> "or upgrade to distillery as build tool. You find more information\n"
-                              <> "about how to upgrade on the edeliver wiki page:\n\n"
-                              <> "https://github.com/boldpoker/edeliver/wiki/Upgrade-from-exrm-to-distillery-as-build-tool\n\n"
+          Mix.Shell.IO.error "Failed to detect whether :distillery or :exrm is used as dependency.\n"
+                          <> "If you used exrm before (default), please add it to your mix.exs\n"
+                          <> "config file like this:\n\n"
+                          <> "defp deps do\n"
+                          <> "  [\n"
+                          <> "   ...\n"
+                          <> "   {:exrm, \">= 0.16.0\", warn_missing: false},\n"
+                          <> "  ]\n"
+                          <> "end\n\n"
+                          <> "or upgrade to distillery as build tool. You find more information\n"
+                          <> "about how to upgrade on the edeliver wiki page:\n\n"
+                          <> "https://github.com/boldpoker/edeliver/wiki/Upgrade-from-exrm-to-distillery-as-build-tool\n\n"
 
-              System.halt(1)
-          end
+          System.halt(1)
       end
       rescue error ->
         Mix.Shell.IO.error "Error when detecting whether distillery or exrm is used as release build tool: #{inspect error}"


### PR DESCRIPTION
- There was no mention in the documentation that you had to add configuration to distillery to tell it to use the `Releases.Plugin.ModifyRelup` plugin. This may need to be made even more obvious in the README or something?
- The plugin was using the wrong `output_dir` (so it was never able to find the `relup_file` and was silently skipping the modifications)
- Docs weren't being generated/published for the distillery plugins
- Fixed some typos in docs (references to exrm instead of distillery in the plugins, and the relup patching docs sample trying to pass an atom to String.to_atom)