### PR TITLE
Should use `profile.output_dir` instead `output_dir` in LinkConfig plugin

### DIFF
--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -23,10 +23,11 @@ defmodule Releases.Plugin.LinkConfig do
 
   def before_package(_), do: nil
 
-  def after_package(%Release{version: version, output_dir: output_dir, name: name}) do
+  def after_package(%Release{version: version, profile: profile, name: name} = release) do
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
     # which resoves the links using the `:dereference` option when creating the tar using the
     # `:erl_tar` module.
+    output_dir = profile.output_dir
     tmp_dir = "_edeliver_release_patch"
     tmp_path = Path.join [output_dir, "releases", version, tmp_dir]
     files_to_link = [


### PR DESCRIPTION
Even if distillery's `output_dir` and `RELEASE_DIR` is configured, LinkConfig plugin always reference default `output_dir` path(`_build/prod/rel/$APP`).

[According to bitwalker's comment](https://github.com/bitwalker/distillery/issues/367#issuecomment-348302981), should use `release.profile.output_dir` for the precise configuration.

cf. https://github.com/edeliver/edeliver/issues/219