### PR TITLE
Problem: Upgrade with Distillery failure due to changed output folder

### DIFF
--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -148,7 +148,7 @@ run() {
     # when generating upgrades with `mix release` (exrm) the old
     # release must be uploaded before generating the release.
     # `erlang_generate_release` generates the upgrade then automatically
-    RELEASE_DIR="${RELEASE_DIR:-"${DELIVER_TO}/rel/${APP}"}"
+    RELEASE_DIR="${RELEASE_DIR:-"${DELIVER_TO}/_build/${TARGET_MIX_ENV}/rel/${APP}"}"
     local _release_destination_path="$(dirname $RELEASE_DIR)"
     [[ "$RELEASE_FILE" =~ upgrade\.tar\.gz$ ]] && _release_destination_path="${_release_destination_path%%/}/${APP}"
     upload_release_archive "$_release_destination_path" "$RELEASE_FILE" "$WITH"


### PR DESCRIPTION
Solution: Update output folder for non-rebar upgrades

This will break exrm compatibility, which is not that bad since exrm shouldn't be used anymore.

Details: https://github.com/bitwalker/distillery/blob/master/CHANGELOG.md#changed-6

closes #182 