### PR TITLE
Make tests run everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ gh-pages/*
 .DS_Store
 deps
 _build
+.idea
+edeliver.iml

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Edeliver.Mixfile do
   defp deps do
     [
       {:distillery, ">= 1.0.0", optional: true, warn_missing: false},
-      {:meck, "~> 0.8.4", only: :test},
+      {:meck, "~> 0.8.9", only: :test},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.11.5", only: :dev},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{"distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"}}

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -1,4 +1,4 @@
-
+# If these tests don't run because :cover is missing, install `erlang-tools`
 defmodule Edeliver.Release.Version.Test do
   use ExUnit.Case
   alias Mix.Tasks.Release.Version, as: ReleaseVersion
@@ -20,19 +20,19 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "mocking get git revision" do
-    assert "82a5834" = get_git_revision
+    assert "82a5834" = get_git_revision()
   end
 
   test "mocking get commit count" do
-    assert "12345" = get_commit_count
+    assert "12345" = get_commit_count()
   end
 
   test "mocking get current branch" do
-    assert "feature-xyz" = get_branch
+    assert "feature-xyz" = get_branch()
   end
 
   test "mocking get current date" do
-    assert "20160414" = get_date
+    assert "20160414" = get_date()
   end
 
   test "printing current release version for show argument" do
@@ -70,7 +70,7 @@ defmodule Edeliver.Release.Version.Test do
   end
 
   test "append git branch only unless master" do
-    assert <<_,_::binary>> = mocked_branch = get_branch
+    assert <<_,_::binary>> = mocked_branch = get_branch()
     assert mocked_branch != "master"
     try do
       assert {:modified, "1.0.0+feature-xyz"} = modify_version_with_args "1.0.0", "append-git-branch-unless-master"
@@ -86,7 +86,7 @@ defmodule Edeliver.Release.Version.Test do
       assert {:modified, "1.2.3+82a5834"} = modify_version_with_args "1.2.3", "branch-unless-master+git-revision"
     after
       :meck.expect(ReleaseVersion, :get_branch, fn -> mocked_branch end)
-      assert mocked_branch == get_branch
+      assert mocked_branch == get_branch()
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,11 +12,11 @@ defmodule Edeliver.BashScript.Case do
       def call(bash_script_file = <<_,_::binary>>, function = <<_,_::binary>>, args) when is_list(args) do
         assert File.exists? bash_script_file
         args = args |> Enum.map(&("\\\"#{&1}\\\"")) |> Enum.join(" ")
-        "/usr/bin/env bash <<<\"
+        "/usr/bin/env bash -c \"
           set -e
           source \\\"#{bash_script_file}\\\"
           2>&1 #{function} #{args}
-        \"" |> String.to_char_list() |> :os.cmd() |> IO.chardata_to_string() |> String.rstrip(?\n)
+        \"" |> String.to_charlist() |> :os.cmd() |> IO.chardata_to_string() |> String.trim_trailing()
       end
       def call(function = <<_,_::binary>>, arg1 = <<_,_::binary>>, arg2 = <<_,_::binary>>), do: call(function, [arg1, arg2])
       def call(function = <<_,_::binary>>, arg1 = <<_,_::binary>>), do: call(function, [arg1])


### PR DESCRIPTION
`:os.cmd()` uses dash by default on ubuntu. Dash does not support `<<<`. So just before giving up, I found out that the bash command supports a -c option, so `<<<` can be avoided completely.

Bonus: This has the advantage that the exit status is properly propagated.