### PR TITLE
bug: Ranch process is not being detected in Phoenix 1.3

### DIFF
--- a/lib/edeliver/relup/instructions/check_ranch_acceptors.ex
+++ b/lib/edeliver/relup/instructions/check_ranch_acceptors.ex
@@ -72,6 +72,7 @@ defmodule Edeliver.Relup.Instructions.CheckRanchAcceptors do
     matching_children = Supervisor.which_children(endpoint_pid) |> Enum.filter(fn(child) ->
       case child do
         {Phoenix.Endpoint.Server, _pid, _type, [Phoenix.Endpoint.Server]} -> true
+        {Phoenix.Endpoint.Handler, _pid, _type, [Phoenix.Endpoint.Handler]} -> true
         _ -> false
       end
     end)


### PR DESCRIPTION
Seems that it was removed in 1.3 in favor of Phoenix.Endpoint.Handler