### PR TITLE
Fix some warnings

### DIFF
--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -17,11 +17,15 @@ defmodule Releases.Plugin.LinkConfig do
   use Mix.Releases.Plugin
 
 
-  def before_assembly(_), do: nil
+  def before_assembly(_, _), do: nil
 
-  def after_assembly(_), do: nil
+  def after_assembly(_, _), do: nil
 
-  def before_package(_), do: nil
+  def before_package(_, _), do: nil
+
+  def after_package(_, _), do: nil
+
+  def after_cleanup(_, _), do: nil
 
   def after_package(%Release{version: version, profile: profile, name: name} = release) do
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
@@ -67,7 +71,5 @@ defmodule Releases.Plugin.LinkConfig do
     end
     nil
   end
-
-  def after_cleanup(_), do: nil
 
 end

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -25,8 +25,6 @@ defmodule Releases.Plugin.LinkConfig do
 
   def after_package(_, _), do: nil
 
-  def after_cleanup(_, _), do: nil
-
   def after_package(%Release{version: version, profile: profile, name: name}) do
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
     # which resoves the links using the `:dereference` option when creating the tar using the
@@ -71,5 +69,7 @@ defmodule Releases.Plugin.LinkConfig do
     end
     nil
   end
+
+  def after_cleanup(_, _), do: nil
 
 end

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -47,8 +47,8 @@ defmodule Releases.Plugin.LinkConfig do
         :ok = File.mkdir_p tmp_path
         ln_binary = <<_,_::binary>>  = System.find_executable "ln"
         debug "Extracting release tar to #{tmp_dir}"
-        :ok = :erl_tar.extract(tar_file, [{:cwd, to_char_list(tmp_path)}, :compressed])
-        directories_to_include = for dir <- File.ls!(tmp_path), do: {to_char_list(dir), to_char_list(Path.join(tmp_path, dir))}
+        :ok = :erl_tar.extract(tar_file, [{:cwd, to_charlist(tmp_path)}, :compressed])
+        directories_to_include = for dir <- File.ls!(tmp_path), do: {to_charlist(dir), to_charlist(Path.join(tmp_path, dir))}
         for {source, destination} <- files_to_link do
           debug "Linking #{source} to #{destination}"
           {_, 0} = System.cmd ln_binary,  ["-sf", source, destination], stderr_to_stdout: true

--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -27,7 +27,7 @@ defmodule Releases.Plugin.LinkConfig do
 
   def after_cleanup(_, _), do: nil
 
-  def after_package(%Release{version: version, profile: profile, name: name} = release) do
+  def after_package(%Release{version: version, profile: profile, name: name}) do
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
     # which resoves the links using the `:dereference` option when creating the tar using the
     # `:erl_tar` module.

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -96,13 +96,13 @@ defmodule Releases.Plugin.ModifyRelup do
           {:ok, {mod, chunks}} = :beam_lib.chunks('#{path}', [:attributes])
           {mod, get_in(chunks, [:attributes, :behaviour])}
         end)
-        |> Stream.filter(fn({module, behaviours}) ->
+        |> Stream.filter(fn {module, behaviours} ->
           is_list(behaviours) &&
           Edeliver.Relup.Modification in behaviours &&
           Code.ensure_loaded?(module) &&
           module.usable?(release)
         end)
-        |> Stream.map(fn({module, _}) ->
+        |> Stream.map(fn {module, _} ->
           {module, module.priority}
         end)
         |> Enum.uniq()

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -96,12 +96,13 @@ defmodule Releases.Plugin.ModifyRelup do
           {:ok, {mod, chunks}} = :beam_lib.chunks('#{path}', [:attributes])
           {mod, get_in(chunks, [:attributes, :behaviour])}
         end)
-        |> Stream.filter_map(fn {module, behaviours} ->
+        |> Stream.filter(fn({module, behaviours}) ->
           is_list(behaviours) &&
           Edeliver.Relup.Modification in behaviours &&
           Code.ensure_loaded?(module) &&
           module.usable?(release)
-        end, fn {module, _} ->
+        end)
+        |> Stream.map(fn({module, _}) ->
           {module, module.priority}
         end)
         |> Enum.uniq()

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -15,7 +15,7 @@ defmodule Releases.Plugin.ModifyRelup do
   use Mix.Releases.Plugin
   alias Edeliver.Relup.Instructions
 
-  def before_assembly(_), do: nil
+  def before_assembly(_, _), do: nil
 
   def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Mix.Releases.Profile{output_dir: output_dir}}) do
     case System.get_env "SKIP_RELUP_MODIFICATIONS" do
@@ -59,13 +59,13 @@ defmodule Releases.Plugin.ModifyRelup do
     end
     nil
   end
-  def after_assembly(_), do: nil
+  def after_assembly(_, _), do: nil
 
-  def before_package(_), do: nil
+  def before_package(_, _), do: nil
 
-  def after_package(_), do: nil
+  def after_package(_, _), do: nil
 
-  def after_cleanup(_), do: nil
+  def after_cleanup(_, _), do: nil
 
   defp changed_modules([{:load_object_code, {name, version, modules}}|_], name, version), do: modules
   defp changed_modules([_|rest], name, version), do: changed_modules(rest, name, version)

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -30,7 +30,7 @@ defmodule Releases.Plugin.ModifyRelup do
         end
         debug "Using #{inspect relup_modification_module} module for relup modification."
         if File.exists?(relup_file) do
-          case :file.consult(to_char_list(relup_file)) do
+          case :file.consult(to_charlist(relup_file)) do
             {:ok, [{up_version,
                     [{down_version, up_description, up_instructions}],
                     [{down_version, down_description, down_instructions}]

--- a/lib/edeliver.ex
+++ b/lib/edeliver.ex
@@ -137,6 +137,10 @@ defmodule Edeliver do
     Path.join([lib_dir, application_with_version, "priv", "repo", "migrations"])
   end
 
+  def init(args) do
+    {:ok, args}
+  end
+
   defp ecto_repository!(_application_name, ecto_repository = [_|_] ) do
     # repository name was passed as ECTO_REPOSITORY env by the erlang-node-execute rpc call
     List.to_atom ecto_repository


### PR DESCRIPTION
fix below warnings.

- `Kernel.to_char_list/1 is deprecated`
- `Mix.Releases.Plugin` behaviour needs callback functions
- `Stream.filter_map/3 is deprecated`
-  delete not using val
- `GenServer` behaviour needs init/1 func