### PR TITLE
New autoversion -time

### DIFF
--- a/docs/auto-versioning.md
+++ b/docs/auto-versioning.md
@@ -52,6 +52,7 @@ To append metadata permanentely you can set the `AUTO_VERSION` configuration var
   * `[git-]branch` Appends the current branch that is built.
   * `[git-]branch-unless-master` Appends the current branch that is built but only unless it is the master branch.
   * `[build-]date` Appends the build date as YYYYMMDD.
+  * `[build-]time` Appends the build time as HHMMSS.
   * `[git-]commit-count[-all[-branches]` Appends the number of commits across all branches.
     Allows edeliver to detect which version is newer if it is appended as first metadata to
     the release version.

--- a/lib/mix/tasks/release_version.ex
+++ b/lib/mix/tasks/release_version.ex
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Release.Version do
     * `[append-][git-]branch[-unless-master]` Appends the current branch that is built. If
       `-unless-master` is used, the branch is only appended unless it is the master branch.
     * `[append-][build-]date` Appends the build date as YYYYMMDD
+    * `[append-][build-]time` Appends the build date as HHMMSS
     * `[append-][git-]commit-count[-all[-branches]|-branch]` Appends the number of commits
     * `[append-]mix-env` Appends the mix environment used while building the release
       from the current branch or across all branches (default).  Appending the commit count
@@ -157,7 +158,7 @@ defmodule Mix.Tasks.Release.Version do
   """
   @spec parse_args(OptionParser.argv) :: :show | {:error, message::String.t} | {:modify, [modification_fun]}
   def parse_args(args) do
-    append_metadata_options = ["commit_count", "commit_count_branch", "revision", "date", "branch", "branch_unless_master", "mix_env"]
+    append_metadata_options = ["commit_count", "commit_count_branch", "revision", "date", "time", "branch", "branch_unless_master", "mix_env"]
     update_version_options  = ["major", "minor", "patch", "set"]
 
     args = normalize_args(args)
@@ -268,6 +269,7 @@ defmodule Mix.Tasks.Release.Version do
   def modify_version_commit_count_branch({version, has_metadata}), do: {add_metadata(version, __MODULE__.get_commit_count_branch, has_metadata), _has_metadata = true}
   def modify_version_revision({version, has_metadata}),            do: {add_metadata(version, __MODULE__.get_git_revision, has_metadata),        _has_metadata = true}
   def modify_version_date({version, has_metadata}),                do: {add_metadata(version, __MODULE__.get_date, has_metadata),                _has_metadata = true}
+  def modify_version_time({version, has_metadata}),                do: {add_metadata(version, __MODULE__.get_time, has_metadata),                _has_metadata = true}
   def modify_version_branch({version, has_metadata}),              do: {add_metadata(version, __MODULE__.get_branch, has_metadata),              _has_metadata = true}
   def modify_version_branch_unless_master({version, has_metadata}) do
     case __MODULE__.get_branch do
@@ -372,5 +374,12 @@ defmodule Mix.Tasks.Release.Version do
   def get_date() do
     {{year, month, day}, _time} = :calendar.local_time
     :io_lib.format('~4.10.0b~2.10.0b~2.10.0b', [year, month, day]) |> IO.iodata_to_binary
+  end
+
+  @doc "Gets the current date in the form hhmmss"
+  @spec get_time :: String.t
+  def get_time() do
+    {_date, {hour, minute, second}} = :calendar.local_time
+    :io_lib.format('~2.10.0b~2.10.0b~2.10.0b', [hour, minute, second]) |> IO.iodata_to_binary
   end
 end

--- a/test/release_version_test.exs
+++ b/test/release_version_test.exs
@@ -12,6 +12,7 @@ defmodule Edeliver.Release.Version.Test do
     :meck.expect(ReleaseVersion, :get_commit_count_branch, fn ->   "4321" end)
     :meck.expect(ReleaseVersion, :get_branch, fn -> "feature-xyz" end)
     :meck.expect(ReleaseVersion, :get_date, fn -> "20160414" end)
+    :meck.expect(ReleaseVersion, :get_time, fn -> "110160" end)
     :ok
   end
 
@@ -33,6 +34,10 @@ defmodule Edeliver.Release.Version.Test do
 
   test "mocking get current date" do
     assert "20160414" = get_date()
+  end
+
+  test "mocking get current time" do
+    assert "110160" = get_time()
   end
 
   test "printing current release version for show argument" do
@@ -94,6 +99,12 @@ defmodule Edeliver.Release.Version.Test do
     assert {:modified, "1.0.0+20160414"} = modify_version_with_args "1.0.0", "append-build-date"
     assert {:modified, "1.0.1+20160414"} = modify_version_with_args "1.0.1", "build-date"
     assert {:modified, "1.2.3+20160414"} = modify_version_with_args "1.2.3", "date"
+  end
+
+  test "appending time" do
+    assert {:modified, "1.0.0+110160"} = modify_version_with_args "1.0.0", "append-build-time"
+    assert {:modified, "1.0.1+110160"} = modify_version_with_args "1.0.1", "build-time"
+    assert {:modified, "1.2.3+110160"} = modify_version_with_args "1.2.3", "time"
   end
 
   test "appending commit count and git revision" do


### PR DESCRIPTION
Hi autoversion-ing is great,

currently I'm using this format `AUTO_VERSION="build-date+revision"`

but I can deploy multiple times a day and the git `revision` is just a random string and cannot be properly sorted, while `commit-count` is great, it doesn't tell you anything contextual

so my PR will add new autoversion format `time`, to append local time to autoversion, so I can use it like this `AUTO_VERSION="build-date+time+revision"`