### PR TITLE
Fix plugins

### DIFF
--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -23,9 +23,7 @@ defmodule Releases.Plugin.LinkConfig do
 
   def before_package(_, _), do: nil
 
-  def after_package(_, _), do: nil
-
-  def after_package(%Release{version: version, profile: profile, name: name}) do
+  def after_package(%Release{version: version, profile: profile, name: name}, _) do
     # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
     # which resoves the links using the `:dereference` option when creating the tar using the
     # `:erl_tar` module.

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -17,7 +17,7 @@ defmodule Releases.Plugin.ModifyRelup do
 
   def before_assembly(_, _), do: nil
 
-  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Mix.Releases.Profile{output_dir: output_dir}}) do
+  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Mix.Releases.Profile{output_dir: output_dir}}, _) do
     case System.get_env "SKIP_RELUP_MODIFICATIONS" do
       "true" -> nil
       _ ->
@@ -59,7 +59,6 @@ defmodule Releases.Plugin.ModifyRelup do
     end
     nil
   end
-  def after_assembly(_, _), do: nil
 
   def before_package(_, _), do: nil
 


### PR DESCRIPTION
First in distillery's Mix.Releases.Plugin, watching 2-arity function, otherwise 1-arity: https://github.com/bitwalker/distillery/blob/master/lib/mix/lib/releases/plugins/plugin.ex#L211
Plugins was broken by this commit: https://github.com/edeliver/edeliver/commit/3fbcda05756c7475686410cc4c9964edbaf72d2f#diff-54433280d02e1346367d6df697291dd7. Empty 2-arity functions added, but logic remains in 1-arity functions.

Please, check my fixes/