### PR TITLE
Fix git clean remote

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -939,9 +939,9 @@ git_clean_remote() {
       set -e
       cd $BUILD_AT
       echo \"cleaning files in: $GIT_CLEAN_PATHS\"
-      for _clean_path in $GIT_CLEAN_PATHS[@]
+      for _clean_path in "${GIT_CLEAN_PATHS[@]}"
       do
-        git clean -ffdx \$_clean_path
+        git clean -ffdx \"\${_clean_path}\"
       done
     "
   fi

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -937,9 +937,12 @@ git_clean_remote() {
     __sync_remote "
       [ -f ~/.profile ] && source ~/.profile
       set -e
-      cd $DELIVER_TO
+      cd $BUILD_AT
       echo \"cleaning files in: $GIT_CLEAN_PATHS\"
-      git clean -ffdx $GIT_CLEAN_PATHS
+      for _clean_path in $GIT_CLEAN_PATHS[@]
+      do
+        git clean -ffdx \$_clean_path
+      done
     "
   fi
 }

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -939,7 +939,7 @@ git_clean_remote() {
       set -e
       cd $BUILD_AT
       echo \"cleaning files in: $GIT_CLEAN_PATHS\"
-      for _clean_path in "${GIT_CLEAN_PATHS[@]}"
+      for _clean_path in ${GIT_CLEAN_PATHS[@]}
       do
         git clean -ffdx \"\${_clean_path}\"
       done


### PR DESCRIPTION
This will make git clean cd to the correct path BUILD_AT instead of DELIVER_TO. DELIVER_TO is the path of the deploy host while BUILD_AT is the build server that needs to be cleaned.

Also fix git clean with multiple long paths "_build/edge/rel rel/app priv/static/generated"