### PR TITLE
solves issue if perl isnt in usr bin

### DIFF
--- a/libexec/aws
+++ b/libexec/aws
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright 2007-2010 Timothy Kay
 # http://timkay.com/aws/


### PR DESCRIPTION
some people have perl installed in other places. All other bash scripts correctly use /usr/bin/env to work around this in this project except this one.