### PR TITLE
Allow time to be passed for auto-version and correct version info.

### DIFF
--- a/libexec/defaults
+++ b/libexec/defaults
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-DELIVER_VERSION="1.4.5"
-HOMEPAGE="https://github.com/boldpoker/edeliver"
+DELIVER_VERSION="1.6.1"
+HOMEPAGE="https://github.com/edeliver/edeliver"
 CREATOR="bharendt"
 
 ARGS="$@"

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -49,7 +49,7 @@ __help() {
       --skip-mix-clean  Skip the 'mix clean step' for faster builds. Use in addition to --skip-git-clean
       --skip-relup-mod  Skip modification of relup file. Custom relup instructions are not added
       --relup-mod=<module-name> The name of the module to modify the relup
-      --auto-version=revision|commit-count|branch|date Automatically append metadata to release version.
+      --auto-version=revision|commit-count|branch|date|time Automatically append metadata to release version.
       --increment-version=major|minor|patch Increment the version for the current build.
       --set-version=<release-version> Set the release version for the current build.
       --start-deploy    Starts the deployed release. If release is running, it is restarted!
@@ -453,7 +453,7 @@ do
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#append-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#git-*}
           AUTO_VERSION_ARG=${AUTO_VERSION_ARG#build-*}
-          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|commit-count-branch|commit-count-all|commit-count-all-branches|branch|branch-unless-master|date)$ ]]; then
+          if ! [[ "$AUTO_VERSION_ARG" =~  ^(revision|commit-count|commit-count-branch|commit-count-all|commit-count-all-branches|branch|branch-unless-master|date|time)$ ]]; then
             __help; error_message "Illegal value for --auto-version= option: '${ORIGINAL_AUTO_VERSION_ARG}'.\n"; exit 2
           fi
         done

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Edeliver.Mixfile do
   def project do
     [
       app: :edeliver,
-      version: "1.6.0",
+      version: "1.6.1",
       description:  "Build and Deploy Elixir Applications and perform Hot-Code Upgrades and Schema Migrations",
       elixirc_paths: elixirc_paths(),
       package: [


### PR DESCRIPTION
Currently with `{:edeliver, "~> 1.6"}` the `build-time` option for the `--auto-version` flag does not work. 

For example the command `mix edeliver build release --auto-version=build-time` returns the error: `Illegal value for --auto-version= option: 'build-time'.`

The problem is that the shell scripts that pass the options along were not updated with the relevant Elixir code. The PR updates those scripts to accept `bulild-time`, as well as updating some script info, and bumping the version code.

Let me know if bumping the version shouldn't be part of this PR, and I can revert.