### PR TITLE
Compatibility with Distillery 2.10.0 and Elixir 1.9

### DIFF
--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -14,7 +14,7 @@ defmodule Releases.Plugin.LinkConfig do
     end
     ```
   """
-  use Mix.Releases.Plugin
+  use Distillery.Releases.Plugin
 
 
   def before_assembly(_, _), do: nil

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -12,12 +12,12 @@ defmodule Releases.Plugin.ModifyRelup do
     end
     ```
   """
-  use Mix.Releases.Plugin
+  use Distillery.Releases.Plugin
   alias Edeliver.Relup.Instructions
 
   def before_assembly(_, _), do: nil
 
-  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Mix.Releases.Profile{output_dir: output_dir}}, _) do
+  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Distillery.Releases.Profile{output_dir: output_dir}}, _) do
     case System.get_env "SKIP_RELUP_MODIFICATIONS" do
       "true" -> nil
       _ ->

--- a/lib/edeliver/relup/release_config.ex
+++ b/lib/edeliver/relup/release_config.ex
@@ -2,7 +2,7 @@ defmodule Edeliver.Relup.Config do
   @moduledoc """
     This type represents the current config of the release manager.
 
-    when using distillery it is a `Mix.Releases.Config.t` struct.
+    when using distillery it is a `Distillery.Releases.Config.t` struct.
   """
 
   @type t :: term

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Edeliver.Mixfile do
 
   defp deps do
     [
-      {:distillery, "~> 2.0", optional: true, warn_missing: false},
+      {:distillery, "~> 2.1.0", optional: true, warn_missing: false},
       {:meck, "~> 0.8.9", only: :test},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.19", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "artificery": {:hex, :artificery, "0.2.6", "f602909757263f7897130cbd006b0e40514a541b148d366ad65b89236b93497a", [:mix], [], "hexpm"},
-  "distillery": {:hex, :distillery, "2.0.2", "58e15f6708e355b610a48356ef170e63ec7753e35e215b107e1e87ed79c65170", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
+  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
+  "distillery": {:hex, :distillery, "2.1.0", "5f31c7771923c12dbb79dcd8d01c5913b07222f134c327e7ab026acdabae985b", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Per [this changelog](https://hexdocs.pm/distillery/changelog.html#breaking-changes), Distillery renamed a few of their modules to be compatible with [Elixir 1.9's releases](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/). This, in turn, broke edeliver for users on 1.9 who still wish to use the Distillery/edeliver flow (mostly, for those who want relups and/or 

Note that this bumps edeliver's minimum version requirements to Elixir 1.9, so this should probably be a major release if it (or something like it) is merged in. Happy to do additional work if asked 😄 