### PR TITLE
Fix submodules for builds

### DIFF
--- a/strategies/erlang-build-appup
+++ b/strategies/erlang-build-appup
@@ -26,12 +26,14 @@ run() {
     git_push
     git_reset_remote
     git_clean_remote
+    git_submodules
   elif [[ -n "$FROM" ]]; then
     # push current state
     init_app_remotely
     git_push
     git_reset_remote
     git_clean_remote
+    git_submodules
     # checkout old version
     git_checkout_remote $FROM
     # build old release

--- a/strategies/erlang-build-release
+++ b/strategies/erlang-build-release
@@ -56,6 +56,7 @@ run() {
   git_push
   git_reset_remote
   git_clean_remote
+  git_submodules
   authorize_release_store_on_build_host
   erlang_get_and_update_deps
   erlang_clean_compile

--- a/strategies/erlang-build-upgrade
+++ b/strategies/erlang-build-upgrade
@@ -87,12 +87,14 @@ run() {
     git_push
     git_reset_remote
     git_clean_remote
+    git_submodules
   elif [[ -n "$FROM" ]]; then
     # push current state
     init_app_remotely
     git_push
     git_reset_remote
     git_clean_remote
+    git_submodules
     # checkout old version
     git_checkout_remote $FROM
     # build old release


### PR DESCRIPTION
Currently "build *" commands do not initialise and/or synchronise submodules or projects, which can be useful for Elixir umbrella projects with ./apps/* structured as submodules.

PR fixes that by adding (apparently unused) stage git_submodules to building pipeline.