### PR TITLE
added '--only prod' option at mix get.deps.

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -125,7 +125,7 @@ erlang_get_and_update_deps() {
         echo \"rebar and rebar3 for mix was built already\"
       fi
       APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD local.hex --force
-      APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD deps.get
+      APP=\"$APP\" MIX_ENV=\"$TARGET_MIX_ENV\" $MIX_CMD deps.get --only prod
     fi
   "
   __exec_if_defined "post_erlang_get_and_update_deps"


### PR DESCRIPTION
problem:
```
mix edeliver build release --branch=develop --verbose
......
Dependencies have diverged:
* hackney (https://github.com/benoitc/hackney.git)
  different specs were given for the hackney app:

  > In apps/foo/mix.exs:
    {:hackney, [env: :prod, git: "https://github.com/benoitc/hackney.git", override: true]}

  > In deps/bar/apps/baz/mix.exs:
    {:hackney, "~> 1.9", [only: :test, env: :prod, repo: "hexpm", hex: "hackney"]}

  Ensure they match or specify one of the above in your deps and set "override: true" 
** (Mix) Can't continue due to errors on dependencies
```

I needed `mix deps.get --only prod` with somewhat complex dependencies.

I think we need to pass options to `mix deps.get`.

NOTE: this is a quick & dirty solution for my case. i just needed deps with [only: test] to be excluded when release.