### PR TITLE
Add pre_extract_release_archive hook

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -898,6 +898,7 @@ remote_extract_release_archive() {
   local _release_version=${1:-"$VERSION"}
   local _archive_dir=${2:-"$DELIVER_TO"}
   local _archive="${APP}_${_release_version}.tar.gz"
+  __exec_if_defined "pre_extract_release_archive"
   status "Extracting archive ${_archive} into ${_archive_dir}"
   # when building releses with mix, the tar does not contain the app name as subdirectory
   [[ "$RELEASE_CMD" = "mix" ]] && _archive_dir="${_archive_dir%%/}/${APP}"


### PR DESCRIPTION
I have a use case where I need to clean up some files before extracting the deploy archive, since the extract doesn't remove older versions. Being execute just before the extracting process was the ideal scenario, so I've added `pre_extract_release_archive` hook.