### PR TITLE
[WIP] Support for mix.releases for elixir >= 1.9

### DIFF
--- a/lib/distillery/plugins/link_config.ex
+++ b/lib/distillery/plugins/link_config.ex
@@ -1,74 +1,77 @@
-defmodule Releases.Plugin.LinkConfig do
-  @moduledoc """
-    Distillery plugin to link the `vm.args` or `sys.config` file on deploy hosts.
+if Code.ensure_loaded?(Distillery.Releases.Plugin) do
+  defmodule Releases.Plugin.LinkConfig do
+    @moduledoc """
+      Distillery plugin to link the `vm.args` or `sys.config` file on deploy hosts.
 
-    Because distillery uses `:systools_make.make_tar(...)` to create the release
-    tar which resoves all links using the `:dereference` option, the release
-    tar needs to be repackaged including the links. To be able use this plugin,
-    it must be added in the `rel/config.exs` distillery config as plugin like this:
+      Because distillery uses `:systools_make.make_tar(...)` to create the release
+      tar which resoves all links using the `:dereference` option, the release
+      tar needs to be repackaged including the links. To be able use this plugin,
+      it must be added in the `rel/config.exs` distillery config as plugin like this:
 
-    ```
-    environment :prod do
-      ..
-      plugin Releases.Plugin.LinkConfig
-    end
-    ```
-  """
-  use Distillery.Releases.Plugin
-
-
-  def before_assembly(_, _), do: nil
-
-  def after_assembly(_, _), do: nil
-
-  def before_package(_, _), do: nil
-
-  def after_package(%Release{version: version, profile: profile, name: name}, _) do
-    # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
-    # which resoves the links using the `:dereference` option when creating the tar using the
-    # `:erl_tar` module.
-    output_dir = profile.output_dir
-    tmp_dir = "_edeliver_release_patch"
-    tmp_path = Path.join [output_dir, "releases", version, tmp_dir]
-    files_to_link = [
-      {System.get_env("LINK_VM_ARGS"),    Path.join([tmp_path, "releases", version, "vm.args"])},
-      {System.get_env("LINK_SYS_CONFIG"), Path.join([tmp_path, "releases", version, "sys.config"])},
-    ] |> Enum.filter(fn {source, _dest} ->
-      case source do
-        <<_,_::binary>> -> true
-        _ -> false
+      ```
+      environment :prod do
+        ..
+        plugin Releases.Plugin.LinkConfig
       end
-    end)
-    if Enum.count(files_to_link) > 0 do
-      info "Repackaging release with links to config files"
-      try do
-        tar_file = Path.join [output_dir, "releases", version, "#{name}.tar.gz"]
-        true = File.exists? tar_file
-        :ok = File.mkdir_p tmp_path
-        ln_binary = <<_,_::binary>>  = System.find_executable "ln"
-        debug "Extracting release tar to #{tmp_dir}"
-        :ok = :erl_tar.extract(tar_file, [{:cwd, to_charlist(tmp_path)}, :compressed])
-        directories_to_include = for dir <- File.ls!(tmp_path), do: {to_charlist(dir), to_charlist(Path.join(tmp_path, dir))}
-        for {source, destination} <- files_to_link do
-          debug "Linking #{source} to #{destination}"
-          {_, 0} = System.cmd ln_binary,  ["-sf", source, destination], stderr_to_stdout: true
+      ```
+    """
+    use Distillery.Releases.Plugin
+
+
+
+    def before_assembly(_, _), do: nil
+
+    def after_assembly(_, _), do: nil
+
+    def before_package(_, _), do: nil
+
+    def after_package(%Release{version: version, profile: profile, name: name}, _) do
+      # repackage release tar including link, because tar is generated using `:systools_make.make_tar(...)`
+      # which resoves the links using the `:dereference` option when creating the tar using the
+      # `:erl_tar` module.
+      output_dir = profile.output_dir
+      tmp_dir = "_edeliver_release_patch"
+      tmp_path = Path.join [output_dir, "releases", version, tmp_dir]
+      files_to_link = [
+        {System.get_env("LINK_VM_ARGS"),    Path.join([tmp_path, "releases", version, "vm.args"])},
+        {System.get_env("LINK_SYS_CONFIG"), Path.join([tmp_path, "releases", version, "sys.config"])},
+      ] |> Enum.filter(fn {source, _dest} ->
+        case source do
+          <<_,_::binary>> -> true
+          _ -> false
         end
-        debug "Recreating release tar including links"
-        :ok = :erl_tar.create(tar_file, directories_to_include, [:compressed])
-      after
-        tmp_path_exists? = File.exists?(tmp_path) && File.dir?(tmp_path)
-        tmp_path_empty? = tmp_path_exists? && File.ls!(tmp_path) == []
-        tmp_path_contains_rel? = File.exists?(Path.join(tmp_path, "lib")) || File.exists?(Path.join(tmp_path, "releases"))
-        if tmp_path_exists? && (tmp_path_empty? || tmp_path_contains_rel?) do
-          debug "Removing tmp dir used for repackaging tar: #{tmp_path}"
-          File.rm_rf!(tmp_path)
+      end)
+      if Enum.count(files_to_link) > 0 do
+        info "Repackaging release with links to config files"
+        try do
+          tar_file = Path.join [output_dir, "releases", version, "#{name}.tar.gz"]
+          true = File.exists? tar_file
+          :ok = File.mkdir_p tmp_path
+          ln_binary = <<_,_::binary>>  = System.find_executable "ln"
+          debug "Extracting release tar to #{tmp_dir}"
+          :ok = :erl_tar.extract(tar_file, [{:cwd, to_charlist(tmp_path)}, :compressed])
+          directories_to_include = for dir <- File.ls!(tmp_path), do: {to_charlist(dir), to_charlist(Path.join(tmp_path, dir))}
+          for {source, destination} <- files_to_link do
+            debug "Linking #{source} to #{destination}"
+            {_, 0} = System.cmd ln_binary,  ["-sf", source, destination], stderr_to_stdout: true
+          end
+          debug "Recreating release tar including links"
+          :ok = :erl_tar.create(tar_file, directories_to_include, [:compressed])
+        after
+          tmp_path_exists? = File.exists?(tmp_path) && File.dir?(tmp_path)
+          tmp_path_empty? = tmp_path_exists? && File.ls!(tmp_path) == []
+          tmp_path_contains_rel? = File.exists?(Path.join(tmp_path, "lib")) || File.exists?(Path.join(tmp_path, "releases"))
+          if tmp_path_exists? && (tmp_path_empty? || tmp_path_contains_rel?) do
+            debug "Removing tmp dir used for repackaging tar: #{tmp_path}"
+            File.rm_rf!(tmp_path)
+          end
         end
       end
+      nil
     end
-    nil
+    def after_package(_, _), do: nil
+
+    def after_cleanup(_, _), do: nil
+
   end
-  def after_package(_, _), do: nil
-
-  def after_cleanup(_, _), do: nil
-
 end

--- a/lib/distillery/plugins/modify_relup.ex
+++ b/lib/distillery/plugins/modify_relup.ex
@@ -1,128 +1,130 @@
-defmodule Releases.Plugin.ModifyRelup do
-  @moduledoc """
-    Distillery plugin to auto-patch the relup file when building upgrades.
+if Code.ensure_loaded?(Distillery.Releases.Plugin) do
+  defmodule Releases.Plugin.ModifyRelup do
+    @moduledoc """
+      Distillery plugin to auto-patch the relup file when building upgrades.
 
-    To be able use this plugin, it must be added in the `rel/config.exs`
-    distillery config as plugin like this:
+      To be able use this plugin, it must be added in the `rel/config.exs`
+      distillery config as plugin like this:
 
-    ```
-    environment :prod do
-      ..
-      plugin Releases.Plugin.ModifyRelup
-    end
-    ```
-  """
-  use Distillery.Releases.Plugin
-  alias Edeliver.Relup.Instructions
+      ```
+      environment :prod do
+        ..
+        plugin Releases.Plugin.ModifyRelup
+      end
+      ```
+    """
+    use Distillery.Releases.Plugin
+    alias Edeliver.Relup.Instructions
 
-  def before_assembly(_, _), do: nil
+    def before_assembly(_, _), do: nil
 
-  def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Distillery.Releases.Profile{output_dir: output_dir}}, _) do
-    case System.get_env "SKIP_RELUP_MODIFICATIONS" do
-      "true" -> nil
-      _ ->
-        info "Modifying relup file..."
-        relup_file = Path.join([output_dir, "releases", version, "relup"])
-        relup_modification_module = case get_relup_modification_module(release) do
-          [module] -> module
-          modules = [_|_] ->
-            Mix.raise "Found multiple modules implementing behaviour Edeliver.Relup.DefaultModification:\n#{inspect modules}\nPlease use the --relup-mod=<module-name> option."
-        end
-        debug "Using #{inspect relup_modification_module} module for relup modification."
-        if File.exists?(relup_file) do
-          case :file.consult(to_charlist(relup_file)) do
-            {:ok, [{up_version,
-                    [{down_version, up_description, up_instructions}],
-                    [{down_version, down_description, down_instructions}]
-                  }]} when is_atom(relup_modification_module) ->
-              instructions = %Instructions{
-                up_instructions: up_instructions,
-                down_instructions: down_instructions,
-                up_version: List.to_string(up_version),
-                down_version: List.to_string(down_version),
-                changed_modules: changed_modules(up_instructions, name, String.to_charlist(version))
-              }
-              %Instructions{
-                up_instructions: up_instructions,
-                down_instructions: down_instructions,
-              } = relup_modification_module.modify_relup(instructions, release)
-              relup = {up_version,
-                [{down_version, up_description, up_instructions}],
-                [{down_version, down_description, down_instructions}]
-              }
-              write_relup(relup, relup_file)
-            error ->
-              debug "Error when loading relup file: #{:io_lib.format('~p~n', [error])}"
-              Mix.raise "Failed to load relup file from #{relup_file}\nYou can skip this step using the --skip-relup-mod option."
+    def after_assembly(release = %Release{is_upgrade: true, version: version, name: name, profile: %Distillery.Releases.Profile{output_dir: output_dir}}, _) do
+      case System.get_env "SKIP_RELUP_MODIFICATIONS" do
+        "true" -> nil
+        _ ->
+          info "Modifying relup file..."
+          relup_file = Path.join([output_dir, "releases", version, "relup"])
+          relup_modification_module = case get_relup_modification_module(release) do
+            [module] -> module
+            modules = [_|_] ->
+              Mix.raise "Found multiple modules implementing behaviour Edeliver.Relup.DefaultModification:\n#{inspect modules}\nPlease use the --relup-mod=<module-name> option."
           end
-        end
-    end
-    nil
-  end
-  def after_assembly(_, _), do: nil
-
-  def before_package(_, _), do: nil
-
-  def after_package(_, _), do: nil
-
-  def after_cleanup(_, _), do: nil
-
-  defp changed_modules([{:load_object_code, {name, version, modules}}|_], name, version), do: modules
-  defp changed_modules([_|rest], name, version), do: changed_modules(rest, name, version)
-  defp changed_modules(_up_instructions, _name, _version), do: []
-
-  defp write_relup(relup, relup_file) do
-    case :file.open(relup_file, [:write]) do
-      {:ok, fd} ->
-        :io.format(fd, "~p.~n", [relup])
-        :file.close(fd)
-      {:error, reason} ->
-         Mix.raise "Failed to save relup file to #{relup_file}. Reason: #{inspect reason}"
-    end
-  end
-
-  defp get_relup_modification_module(release = %Release{}) do
-    case System.get_env "RELUP_MODIFICATION_MODULE" do
-      module = <<_,_::binary>> ->
-        module = String.to_atom(module)
-        if Code.ensure_loaded?(module) do
-          [module]
-        else
-            Mix.raise "Module used by the --relup-mod=#{inspect module} option cannot be found."
-        end
-      _ -> # find module in path
-        Path.wildcard("**/*/ebin/**/*.{beam}")
-        |> Stream.map(fn path ->
-          {:ok, {mod, chunks}} = :beam_lib.chunks('#{path}', [:attributes])
-          {mod, get_in(chunks, [:attributes, :behaviour])}
-        end)
-        |> Stream.filter(fn {module, behaviours} ->
-          is_list(behaviours) &&
-          Edeliver.Relup.Modification in behaviours &&
-          Code.ensure_loaded?(module) &&
-          module.usable?(release)
-        end)
-        |> Stream.map(fn {module, _} ->
-          {module, module.priority}
-        end)
-        |> Enum.uniq()
-        |> Enum.sort(fn {module_a, priority_a}, {module_b, priority_b} ->
-          cond do
-            module_a == module_b -> true
-            String.starts_with?(Atom.to_string(module_a), "Elixir.Edeliver.Relup.") -> false # prefer custom modules
-            priority_a < priority_b -> false
-            true -> true
+          debug "Using #{inspect relup_modification_module} module for relup modification."
+          if File.exists?(relup_file) do
+            case :file.consult(to_charlist(relup_file)) do
+              {:ok, [{up_version,
+                      [{down_version, up_description, up_instructions}],
+                      [{down_version, down_description, down_instructions}]
+                    }]} when is_atom(relup_modification_module) ->
+                instructions = %Instructions{
+                  up_instructions: up_instructions,
+                  down_instructions: down_instructions,
+                  up_version: List.to_string(up_version),
+                  down_version: List.to_string(down_version),
+                  changed_modules: changed_modules(up_instructions, name, String.to_charlist(version))
+                }
+                %Instructions{
+                  up_instructions: up_instructions,
+                  down_instructions: down_instructions,
+                } = relup_modification_module.modify_relup(instructions, release)
+                relup = {up_version,
+                  [{down_version, up_description, up_instructions}],
+                  [{down_version, down_description, down_instructions}]
+                }
+                write_relup(relup, relup_file)
+              error ->
+                debug "Error when loading relup file: #{:io_lib.format('~p~n', [error])}"
+                Mix.raise "Failed to load relup file from #{relup_file}\nYou can skip this step using the --skip-relup-mod option."
+            end
           end
-        end)
-        |> Enum.reduce({[], nil}, fn {module, priority}, {modules, highest_priority} ->
-          highest_priority = if highest_priority == nil, do: priority, else: highest_priority
-          modules = if priority == highest_priority, do: [module|modules], else: modules
-          {modules, highest_priority}
-        end)
-        |> Tuple.to_list
-        |> List.first
-        |> Enum.reverse
+      end
+      nil
     end
-  end
+    def after_assembly(_, _), do: nil
 
+    def before_package(_, _), do: nil
+
+    def after_package(_, _), do: nil
+
+    def after_cleanup(_, _), do: nil
+
+    defp changed_modules([{:load_object_code, {name, version, modules}}|_], name, version), do: modules
+    defp changed_modules([_|rest], name, version), do: changed_modules(rest, name, version)
+    defp changed_modules(_up_instructions, _name, _version), do: []
+
+    defp write_relup(relup, relup_file) do
+      case :file.open(relup_file, [:write]) do
+        {:ok, fd} ->
+          :io.format(fd, "~p.~n", [relup])
+          :file.close(fd)
+        {:error, reason} ->
+          Mix.raise "Failed to save relup file to #{relup_file}. Reason: #{inspect reason}"
+      end
+    end
+
+    defp get_relup_modification_module(release = %Release{}) do
+      case System.get_env "RELUP_MODIFICATION_MODULE" do
+        module = <<_,_::binary>> ->
+          module = String.to_atom(module)
+          if Code.ensure_loaded?(module) do
+            [module]
+          else
+              Mix.raise "Module used by the --relup-mod=#{inspect module} option cannot be found."
+          end
+        _ -> # find module in path
+          Path.wildcard("**/*/ebin/**/*.{beam}")
+          |> Stream.map(fn path ->
+            {:ok, {mod, chunks}} = :beam_lib.chunks('#{path}', [:attributes])
+            {mod, get_in(chunks, [:attributes, :behaviour])}
+          end)
+          |> Stream.filter(fn {module, behaviours} ->
+            is_list(behaviours) &&
+            Edeliver.Relup.Modification in behaviours &&
+            Code.ensure_loaded?(module) &&
+            module.usable?(release)
+          end)
+          |> Stream.map(fn {module, _} ->
+            {module, module.priority}
+          end)
+          |> Enum.uniq()
+          |> Enum.sort(fn {module_a, priority_a}, {module_b, priority_b} ->
+            cond do
+              module_a == module_b -> true
+              String.starts_with?(Atom.to_string(module_a), "Elixir.Edeliver.Relup.") -> false # prefer custom modules
+              priority_a < priority_b -> false
+              true -> true
+            end
+          end)
+          |> Enum.reduce({[], nil}, fn {module, priority}, {modules, highest_priority} ->
+            highest_priority = if highest_priority == nil, do: priority, else: highest_priority
+            modules = if priority == highest_priority, do: [module|modules], else: modules
+            {modules, highest_priority}
+          end)
+          |> Tuple.to_list
+          |> List.first
+          |> Enum.reverse
+      end
+    end
+
+  end
 end

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -234,6 +234,9 @@ erlang_generate_release() {
     elif [ \"$RELEASE_CMD\" = \"relx\" ]; then
       echo \"using relx to generate release\"
       $RELX_CMD release
+    elif [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
+      echo \"using mix with releases to generate release\"
+      MIX_ENV=\"$TARGET_MIX_ENV\" mix release
     elif [ \"$RELEASE_CMD\" = \"mix\" ]; then
       echo \"using mix to generate release\"
       MIX_ENV=\"$TARGET_MIX_ENV\" LINK_SYS_CONFIG=\"$LINK_SYS_CONFIG\" LINK_VM_ARGS=\"$LINK_VM_ARGS\" APP=\"$APP\" AUTO_VERSION=\"$AUTO_VERSION\" BRANCH=\"$BRANCH\" SKIP_RELUP_MODIFICATIONS=\"$SKIP_RELUP_MODIFICATIONS\" RELUP_MODIFICATION_MODULE=\"$RELUP_MODIFICATION_MODULE\" USING_DISTILLERY=\"$USING_DISTILLERY\" $MIX_CMD $_set_auto_version distillery.release${_force_no_interaction}${_mix_release_verbose_flag}${_env_flag}${_app_flag}${_upgrade_flag}
@@ -279,6 +282,8 @@ erlang_archive_release() {
     elif [ \"$RELEASE_CMD\" = \"relx\" ]; then
       echo \"using relx to archive release\"
       $RELX_CMD tar
+    elif [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
+      tar -zcpf $(dirname $RELEASE_DIR)/${APP}_${RELEASE_VERSION}.tar.gz -C $(dirname $RELEASE_DIR) ${APP}
     fi
   "
 }
@@ -299,7 +304,7 @@ copy_release_to_release_store() {
     if [[ "$USING_DISTILLERY" = "true" ]]; then
       local _release_file="$(dirname $RELEASE_DIR)/${APP}/releases/${RELEASE_VERSION}/${APP}.tar.gz"
     fi
-  else # used rebar to generate release
+  else # used rebar or mix-release to generate release
     local _release_file="$(dirname $RELEASE_DIR)/${APP}_${RELEASE_VERSION}.tar.gz"
   fi
   status "Copying release ${RELEASE_VERSION} to $RELEASE_STORE_TYPE release store"
@@ -407,7 +412,6 @@ upload_file_to_release_store() {
   if [ "$RELEASE_STORE_TYPE" = "s3" ]; then
     upload_file_to_s3_release_store "$_source_file" "$_destination_file"
   elif [ "$RELEASE_STORE_TYPE" = "local" ]; then
-    status "Copying ${_source_file} to local release store"
     [ "$FORCE" != "true" ] && file_exists_in_store $(basename $_destination_file) && {
       read -n1 -p "${txtylw}Destination File '$_destination_file' already uploaded. Overwrite? (y/n)${txtrst}"
       echo
@@ -820,7 +824,7 @@ __get_node_command() {
   local _app_path="$2"
   local _config_arg="$3"
   local _rpc_command="rpc"
-  if [[ "$USING_DISTILLERY" = "true" ]]; then
+  if [[ "$USING_DISTILLERY" = "true" ]] || [[ "$RELEASE_CMD" = "mix-release" ]]; then
     local _rpc_open_brackets="["
     local _rpc_close_brackets="]"
   else
@@ -833,7 +837,13 @@ __get_node_command() {
     [ -f \"\$HOME/.profile\" ] && . \"\$HOME/.profile\"
     set -e
     cd ${_app_path}/${APP} $SILENCE
-    output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
+
+    if [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
+      output_lines=\"\$(bin/${APP} pid 2>&1 | wc -l | tr -d ' ')\"
+    else
+      output_lines=\"\$(bin/${APP} ping | wc -l | tr -d ' ')\"
+    fi
+
     if [ \"\$output_lines\" -gt 1 ]; then
       output_filter_command='tail'
       output_filter_command_options=\"-n+\$output_lines\"
@@ -842,10 +852,20 @@ __get_node_command() {
       output_filter_command_options=''
     fi
     __edeliver_node_running() {
-      bin/${APP} ping 2>/dev/null >/dev/null
+      if [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
+        local __result=\"\$(bin/${APP} pid 2>&1)\"
+        [[ \"\$__result\" =~ [0-9]+ ]]
+      else
+        bin/${APP} ping 2>/dev/null >/dev/null
+      fi
     }
     __edeliver_synchronous_start() {
-      bin/${APP} start | \$output_filter_command \$output_filter_command_options
+      local _start_cmd=\"start\"
+      if [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
+        _start_cmd=\"daemon\"
+      fi
+
+      bin/${APP} \$_start_cmd | \$output_filter_command \$output_filter_command_options
       sleep 1
       for i in 1 2 3 4 5 6 7 8 9 10; do
         __edeliver_node_running && break || :
@@ -855,6 +875,12 @@ __get_node_command() {
     }
     if [ \"$RELEASE_CMD\" = \"mix\" ] && [ \"$_is_start_command\" = \"true\" ]; then
       ping_result=\"\$(bin/${APP} ping | \$output_filter_command \$output_filter_command_options || :)\"
+      if __edeliver_node_running; then
+        echo \"${txtred}already running${txtrst}\" && exit 1
+      else
+        __edeliver_synchronous_start
+      fi
+    elif [ \"$RELEASE_CMD\" = \"mix-release\" ] && [ \"$_is_start_command\" = \"true\" ]; then
       if __edeliver_node_running; then
         echo \"${txtred}already running${txtrst}\" && exit 1
       else

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
-  "distillery": {:hex, :distillery, "2.1.1", "f9332afc2eec8a1a2b86f22429e068ef35f84a93ea1718265e740d90dd367814", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm", "514586f4312ef3709a3ccbd8e55f69455add235c1729656687bb781d10d0afdb"},
+  "distillery": {:hex, :distillery, "2.1.1", "f9332afc2eec8a1a2b86f22429e068ef35f84a93ea1718265e740d90dd367814", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm", "bbc7008b0161a6f130d8d903b5b3232351fccc9c31a991f8fcbf2a12ace22995"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], [], "hexpm", "d34f013c156db51ad57cc556891b9720e6a1c1df5fe2e15af999c84d6cebeb1a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
 }


### PR DESCRIPTION
Closes #322 

**This is a heavy work in progress, and I'm mainly interested in feedback from the author and community in integrating mix-releases with edeliver**

I was really interested in trying out the new `mix releases` but they don't support any out-of-the box delivery mechanisms for shipping the actual build code for production.

## The Approach
So for now, I opted-in just for having a flag for using mix releases. Here's my example config:

```bash
# .deliver/config

APP="deliver_project"

# Instead of auto-detecting we  use the `mix-release` command as the release cmd
RELEASE_CMD="mix-release"

RELEASE_DIR="~/elixir_builds/_build/prod/rel/$APP"

BUILD_HOST="localhost"
BUILD_USER="deployer"
BUILD_AT="~/elixir_builds/"

STAGING_HOSTS="localhost"
STAGING_USER="deployer"
DELIVER_TO="~/elixir_web/"
```

### The Problems

1. The ping issue

One of the problems I've faced is to do with the `ping` command. Unfortunately `mix release` doesn't support the `ping` command out of the box. So the only viable option we have is to use something else, or to re-build the `ping` command as a module inside `edeliver` and use that to execute the `ping`. As I saw how complex the logic behind a simple ping is, I went for the second option which might be a bit hackish. Nonetheless, here's how I solved it:

```bash
__edeliver_node_running() {
      if [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
        local __result=\"\$(bin/${APP} pid 2>&1)\"
        [[ \"\$__result\" =~ [0-9]+ ]]
      else
        bin/${APP} ping 2>/dev/null >/dev/null
      fi
    }
```

Basically, if we have a `pid` assigned using the pid command and if we do, then we know the node is in fact running.

2. start is not a daemon

For some reason, the mix team didn't make the `start` script a daemon. So, instead of doing `bin/appname start` you must do `bin/appname daemon` to get the process running.

Again, since `start` was hard-coded as a option in conjunction with `distillery` I had to add check if we're using `mix-release` and in that case not use the `start` command.

```bash
local _start_cmd=\"start\"
      if [ \"$RELEASE_CMD\" = \"mix-release\" ]; then
        _start_cmd=\"daemon\"
      fi
```

I've made a test project that uses this to demo a release. You can check it out: https://github.com/dev-cyprium/mix-release-edeliver

 ----

### Checklist 
- [x] Fix error when trying to run `mix edeliver` without `distilery`
- [x] Test if it's a non-breaking change
- [x] Deploy an example application with mix releases
- [ ] figure out a proper way of handling application "ping" to see if it's running
- [ ] make sure the `mix edeliver restart` command works
- [x] update documentation on custom modules, `vm.args`, `migrations`, etc.
- [x] add proper env flags to the command `mix release` inside the bash script