### PR TITLE
Build releases using rebar3

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ When using [rebar3](https://github.com/erlang/rebar3), edeliver can be added as 
 
     {deps, [
       % ...
-      {edeliver, {git, "git://github.com/edeliver/edeliver.git", {ref, "f08b1a7ac74ced0c799d0e6567aed30c117b6de7"}}}
+      {edeliver, {git, "git://github.com/edeliver/edeliver.git", {ref, "e103c2b012058168857552562b158e1c76ebfbe9"}}}
     ]}.
 
 And link the `edeliver` binary to the root of your project directory:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ It can be used with any one of these build systems:
 
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases (recommended)
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [relx](https://github.com/erlware/relx) for elixir/erlang releases
-  * [rebar](https://github.com/basho/rebar) for pure erlang releases
+  * [rebar3](https://github.com/erlang/rebar3) for pure erlang releases
+  * [rebar](https://github.com/basho/rebar) for legacy erlang releases
 
 Edeliver tries to autodetect which system to use:
 
@@ -131,7 +132,7 @@ Edeliver tries to autodetect which system to use:
   * If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
   * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades.
 
-This can be overridden by the config variables `BUILD_CMD=rebar|mix`, `RELEASE_CMD=rebar|mix|relx` and `USING_DISTILLERY=true|false` in `.deliver/config`.
+This can be overridden by the config variables `BUILD_CMD=rebar3|rebar|mix`, `RELEASE_CMD=rebar3|rebar|mix|relx` and `USING_DISTILLERY=true|false` in `.deliver/config`.
 
 Edeliver uses ssh and scp to build and deploy the releases.  It is recommended that you use ssh and scp with key+passphrase only.  You can use `ssh-add` if you don't want to enter your passphrase every time.
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ It can be used with any one of these build systems:
 
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [distillery](https://github.com/bitwalker/distillery) for elixir/erlang releases (recommended)
   * [mix](http://elixir-lang.org/getting-started/mix-otp/introduction-to-mix.html) in conjunction with [relx](https://github.com/erlware/relx) for elixir/erlang releases
-  * [rebar3](https://github.com/erlang/rebar3) for pure erlang releases
-  * [rebar](https://github.com/basho/rebar) for legacy erlang releases
+  * [rebar3](https://github.com/erlang/rebar3) for pure erlang releases or in conjunction with [rebar_mix plugin](https://github.com/Supersonido/rebar_mix) to build also Elixir sources and dependencies
+  * [rebar](https://github.com/basho/rebar) for legacy pure erlang releases
 
 Edeliver tries to autodetect which system to use:
 
   * If a `./mix.exs` and a `rel/config.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [distillery](https://github.com/bitwalker/distillery) is used to generate the releases / upgrades.
   * If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
+  * If a `./rebar.config` file exists but no `./relx.config`, [rebar3](https://github.com/erlang/rebar3) is used to fetch the dependencies, compile the sources and to build the release
   * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades.
 
 This can be overridden by the config variables `BUILD_CMD=rebar3|rebar|mix`, `RELEASE_CMD=rebar3|rebar|mix|relx` and `USING_DISTILLERY=true|false` in `.deliver/config`.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Edeliver tries to autodetect which system to use:
   * If a `./mix.exs` and a `rel/config.exs` file exists, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [distillery](https://github.com/bitwalker/distillery) is used to generate the releases / upgrades.
   * If a `./relx.config` file exists in addition to a `./mix.exs` file, [mix](http://elixir-lang.org/getting_started/mix/1.html) is used fetch the dependencies, compile the sources and [relx](https://github.com/erlware/relx) is used to generate the releases / upgrades.
   * If a `./rebar.config` file exists but no `./relx.config`, [rebar3](https://github.com/erlang/rebar3) is used to fetch the dependencies, compile the sources and to build the release
-  * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades.
+  * Otherwise [rebar](https://github.com/basho/rebar) is used to fetch the dependencies, compile the sources and generate the releases / upgrades. It is recommended to [migrate to rebar3](https://rebar3.readme.io/docs/from-rebar-2x-to-rebar3) in that case.
 
 This can be overridden by the config variables `BUILD_CMD=rebar3|rebar|mix`, `RELEASE_CMD=rebar3|rebar|mix|relx` and `USING_DISTILLERY=true|false` in `.deliver/config`.
 
@@ -169,6 +169,25 @@ def application, do: [
   ],
 ]
 ```
+
+### Rebar3 considerations
+
+When using [rebar3](https://github.com/erlang/rebar3), edeliver can be added as [rebar3 dependency](https://rebar3.readme.io/docs/dependencies). Just add it to your `rebar.config` (and ensure that a `./rebar3` binary/link is in your project directory):
+
+    {deps, [
+      % ...
+      {edeliver, {git, "git://github.com/edeliver/edeliver.git", {ref, "f08b1a7ac74ced0c799d0e6567aed30c117b6de7"}}}
+    ]}.
+
+And link the `edeliver` binary to the root of your project directory:
+
+    wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+    ./rebar3 get-deps
+    ln -s ./_build/default/lib/edeliver/bin/edeliver ./edeliver 
+
+
+Then use the linked binary `./edeliver` to build and deploy releases.
+
 
 ### Rebar considerations
 

--- a/libexec/app_config
+++ b/libexec/app_config
@@ -83,16 +83,26 @@ then
 fi
 
 # command to compile the source the remote build host
-# rebar | mix
+# rebar3 | rebar | mix
 if [ -z "$BUILD_CMD" ]; then
-  [[ -f "./mix.exs" ]] && BUILD_CMD=${BUILD_CMD:=mix} || BUILD_CMD=${BUILD_CMD:=rebar}
+  if [ -f "./rebar.config" ] && [[ ! -f "./relx.config" ]]; then
+    BUILD_CMD=${BUILD_CMD:=rebar3}
+  elif [ -f "./mix.exs" ]; then
+    BUILD_CMD=${BUILD_CMD:=mix}
+  else
+    BUILD_CMD=${BUILD_CMD:=rebar}
+  fi
 fi
 
 # command to generate the release on the remote build host
-# mix | rebar | relx
+# mix | rebar3 | rebar | relx
 if [ -z "$RELEASE_CMD" ]; then
   if [[ -f "./relx.config" ]]; then
     RELEASE_CMD=${RELEASE_CMD:=relx}
+  elif [[ -f "./rebar.config" ]]; then
+    # and no relx.config, because release is configured
+    # in rebar.config for rebar3, but not for rebar2
+    RELEASE_CMD=${RELEASE_CMD:=rebar3}
   elif [[ -f "./mix.exs" ]]; then
     RELEASE_CMD=${RELEASE_CMD:=mix}
   else

--- a/libexec/core
+++ b/libexec/core
@@ -121,7 +121,7 @@ __find_all_strategies() {
     strategies_path+=("$ORIGIN_DIR/.deliver/strategies")
   fi
 
-  STRATEGIES=$(find "${strategies_path[@]}" -regex '^[a-zA-Z0-9@_/.-]*$' -type f ! -iname 'readme*')
+  STRATEGIES=$(find "${strategies_path[@]}" -regex '^.*/[a-zA-Z0-9.-]*$' -type f ! -iname 'readme*')
   for strategy in $STRATEGIES
   do
     STRATEGIES_NAME="$STRATEGIES_NAME ${strategy##*/}"

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -21,6 +21,7 @@ else
 fi
 
 REBAR_CMD=${REBAR_CMD:="./rebar $REBAR_OPTIONS"}
+REBAR3_CMD=${REBAR3_CMD:="./rebar3 $REBAR_OPTIONS"}
 MIX_CMD=${MIX_CMD:="mix"}
 RELX_CMD=${RELX_CMD:="./relx"}
 
@@ -114,7 +115,14 @@ erlang_get_and_update_deps() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
-    if [ \"$BUILD_CMD\" = \"rebar\" ]; then
+    if [ \"$BUILD_CMD\" = \"rebar3\" ]; then
+      echo \"using rebar3 to fetch and update deps\"
+      which $REBAR3_CMD || {
+        echo \"installing rebar3\"
+        wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+      }
+      $REBAR3_CMD update get-deps
+    elif [ \"$BUILD_CMD\" = \"rebar\" ]; then
       echo \"using rebar to fetch and update deps\"
       $REBAR_CMD update-deps get-deps
     elif [ \"$BUILD_CMD\" = \"mix\" ]; then
@@ -161,7 +169,11 @@ erlang_clean_compile() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
-    if [ \"$BUILD_CMD\" = \"rebar\" ]; then
+    if [ \"$BUILD_CMD\" = \"rebar3\" ]; then
+      echo \"using rebar3 to compile files\"
+      [[ \"$SKIP_MIX_CLEAN\" != \"true\" ]] && $REBAR3_CMD clean || :
+      $REBAR3_CMD compile
+    elif [ \"$BUILD_CMD\" = \"rebar\" ]; then
       echo \"using rebar to compile files\"
       [[ \"$SKIP_MIX_CLEAN\" != \"true\" ]] && $REBAR_CMD clean skip_deps=true || :
       $REBAR_CMD compile
@@ -228,7 +240,10 @@ erlang_generate_release() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
-    if [ \"$RELEASE_CMD\" = \"rebar\" ]; then
+    if [ \"$RELEASE_CMD\" = \"rebar3\" ]; then
+      echo \"using rebar3 to generate release\"
+      $REBAR3_CMD $RELEASE_CMD_OPTIONS release -n $APP
+    elif [ \"$RELEASE_CMD\" = \"rebar\" ]; then
       echo \"using rebar to generate release\"
       $REBAR_CMD $RELEASE_CMD_OPTIONS -f generate
     elif [ \"$RELEASE_CMD\" = \"relx\" ]; then
@@ -274,7 +289,7 @@ erlang_archive_release() {
     [ -f $PROFILE ] && source $PROFILE
     set -e
     cd $DELIVER_TO
-    if [ \"$RELEASE_CMD\" = \"rebar\" ]; then
+    if [ \"$RELEASE_CMD\" = \"rebar\" ] || [ \"$RELEASE_CMD\" = \"rebar3\" ]; then
       tar -zcpf $(dirname $RELEASE_DIR)/${APP}_${RELEASE_VERSION}.tar.gz -C $(dirname $RELEASE_DIR) ${APP}
     elif [ \"$RELEASE_CMD\" = \"relx\" ]; then
       echo \"using relx to archive release\"
@@ -1096,6 +1111,9 @@ __detect_remote_release_dir() {
         [ -f $PROFILE ] && source $PROFILE
         set -e
         cd $DELIVER_TO $SILENCE
+        if [ \"$RELEASE_CMD\" = \"rebar3\" ]; then
+          cd _build
+        fi
         OS_TYPE=\$(uname)
         if [[ \"\$OS_TYPE\" = \"Darwin\" ]]; then
           find ./ -name RELEASES | cut -b3- | (echo -n "\$PWD" && cat) | grep -E $APP/releases/RELEASES\$


### PR DESCRIPTION
See: [rebar3](https://github.com/erlang/rebar3) which is the successor of rebar2.x and how to [migrate from rebar 2 to rebar 3](https://rebar3.org/docs/tutorials/from_rebar2_to_rebar3/).

