### PR TITLE
Build release as docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ If `BUILD_HOST` is set to `"docker"`, edeliver builds the release in a docker co
 
 ### Build as a docker container
 
-If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to `edeliver/release-base`) and pushed with that image name from the `RELEASE_STORE` to your registry (if `--push` is used). It creates (and optionally pushes) three image tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started on a host authenticated at the same docker registry like this:
+If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to [`edeliver/release-base:1.0`](https://hub.docker.com/r/edeliver/release-base)) and pushed with that image name from the `RELEASE_STORE` to your registry (if `--push` is used). It creates (and optionally pushes) three image tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started on a host authenticated at the same docker registry like this:
 
 ```sh
 docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/echo-server console

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ If `BUILD_HOST` is set to `"docker"`, edeliver builds the release in a docker co
 
 ### Build as a docker container
 
-If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to `edeliver/release-base`) and pushed with that image name from the `RELEASE_STORE` to your registry. It will be pushed with 3 tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started like this:
+If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to `edeliver/release-base`) and pushed with that image name from the `RELEASE_STORE` to your registry (if `--push` is used). It creates (and optionally pushes) three image tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started on a host authenticated at the same docker registry like this:
 
 ```sh
 docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/echo-server console

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ For build commands the following **configuration** variables must be set:
 
 The built release is then **copied to your local directory** `.deliver/releases` and can then be **delivered to your production servers** by using one of the **deploy commands**.
 
-If compiling and generating the release build was successful, the release is **copied from the remote build host** to the **release store**. The default release store is the __local__ `.deliver` __directory__ but you can configure any destination with the `RELEASE_STORE=` environment variables, also __remote ssh destinations__ (in your server network) like `RELEASE_STORE=user@releases.acme.org:/releases/` or **amazon s3** locations like `s3://AWS_ACCESS_KEY_ID@AWS_SECRET_ACCESS_KEY:bucket`. The release is copied from the remote build host using the `RELEASE_DIR=` environment variable. If this is not set, the default directory is found by finding the subdirectory that contains the generated `RELEASES` file and has the `$APP` name in the path. e.g. if `$APP=myApp` and the `RELEASES` file is found at `rel/myApp/myApp/releases/RELEASE` the `rel/myApp/myApp` is copied to the release store.
+If compiling and generating the release build was successful, the release is **copied from the remote build host** to the **release store**. The default release store is the __local__ `.deliver` __directory__ but you can configure any destination with the `RELEASE_STORE=` environment variables, also __remote ssh destinations__ (in your server network) like `RELEASE_STORE=user@releases.acme.org:/releases/`, **amazon s3** locations like `s3://AWS_ACCESS_KEY_ID@AWS_SECRET_ACCESS_KEY:bucket` or as a __docker image__ like `docker://edeliver/echo-server`. The release is copied from the remote build host using the `RELEASE_DIR=` environment variable. If this is not set, the default directory is found by finding the subdirectory that contains the generated `RELEASES` file and has the `$APP` name in the path. e.g. if `$APP=myApp` and the `RELEASES` file is found at `rel/myApp/myApp/releases/RELEASE` the `rel/myApp/myApp` is copied to the release store.
 
 To __build releases__ and upgrades __faster__, you might adjust the `GIT_CLEAN_PATHS` variable in your config file e.g. to something like `="_build rel priv/generated"` which defaults to `.`. That value means, that everything from the last build is reset (beam files, release files, deps, generated assets etc.) before the next build is started to ensure that no conflicts with old (e.g. removed or renamed) files might arise. You can also use the command line option `--skip-git-clean` to skip this step completely and in addition with the `--skip-mix-clean` option for full __incremental builds__.
 
@@ -270,6 +270,14 @@ Builds an initial release that can be deployed to the production hosts. If you w
 ### Build in a docker container
 
 If `BUILD_HOST` is set to `"docker"`, edeliver builds the release in a docker container instead of building on a build host. It uses the docker image set as `DOCKER_BUILD_IMAGE` which defaults to [elixir:1.13.3](https://hub.docker.com/_/elixir) with erlang 24, but can be overridden in your `.deliver/config`. When building in a docker container, the git repository to build is pushed to the local dir `.docker-build` which is then mounted into the container and edelivers build commands are executed as `docker exec` commands in the container.
+
+### Build as a docker container
+
+If `RELEASE_STORE` is a (private) docker image in a docker registry like `docker://edeliver/echo-server` the built release will be embedded into a docker image based on `DOCKER_RELEASE_BASE_IMAGE` (which defaults to `edeliver/release-base`) and pushed with that image name from the `RELEASE_STORE` to your registry. It will be pushed with 3 tags: *release version* + `latest`, *release version* + *git sha* and *release version* + *branch*. The release can then be started like this:
+
+```sh
+docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/echo-server console
+```
 
 ### Build an upgrade package
 

--- a/docker/release-base.dockerfile
+++ b/docker/release-base.dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal-20220113
+
+RUN apt update \
+ && apt install -y libssl1.1 locales \
+ && apt clean
+
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" LANGUAGE="en_US:en"

--- a/libexec/core
+++ b/libexec/core
@@ -391,6 +391,56 @@ __sync_local() {
   fi
 }
 
+# Executes a docker command and hides output unless --verbose flag is set.
+# The output is captured and displayed in case of a failure. If this
+# runs in a subshell e.g. to assign the output to a vaiable 
+# (a container id for instance), the output is printed.
+__docker() {
+  if [ "$(exec sh -c 'echo "$PPID"')" != "$$" ]; then
+     local _stderr _status
+     exec 3>&2 # save stderr
+     exec 2>&1 # redirect stderr to stdout because command swapps stdout <> stderr
+     # execute command with stdout <> stderr swapped
+     _stderr="$(docker $@ 3>&1 1>&2 2>&3)" || error "
+Error output: >>> -------------
+
+$_stderr
+
+<<< Error output --------------
+
+Command 'docker $@'
+
+failed with status code $?!
+
+Error output is displayed above.
+
+    " >&3 # redirect to old stderr
+  else # not in a subshell
+    if [ "$VERBOSE" = "true" ]; then
+      docker $@ || error "
+
+Command 'docker $@'
+
+failed with status code $?!
+
+Error output is displayed above.
+"
+    else # not verbose
+      local _stdout
+      _stdout="$(docker $@)" || error "
+$_stderr
+
+Command 'docker $@'
+
+failed with status code $?!
+
+Stdout and error output is displayed above."
+    fi
+  fi
+
+}
+
+
 # monitors the parent pid if edeliver is started by a mix task.
 # this is required because edeliver is started from an erlang node
 # using "Port.open({:spawn, edeliver_command}, options)" and will

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -413,6 +413,11 @@ EOF
     "
     ssh -A -S none -o ConnectTimeout="$SSH_TIMEOUT" "$_build_hosts" "$_remote_job $SILENCE" || \
       error "Copying release file failed\n  source: $_release_file on $_build_hosts\n  destination: $_dest_file_name on $_release_store_host"
+  elif [ "$RELEASE_STORE_TYPE" = "docker" ]; then
+    status "Generating docker image with release"
+    info "Creating image $DOCKER_RUN_IMAGE"
+    info "Using base image $DOCKER_RELEASE_BASE_IMAGE"
+    info "Tagging as ${RELEASE_VERSION}-latest"
   else
     error_message "Cannot copy releases to store for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi
@@ -1235,12 +1240,14 @@ __show_upgrade_version_does_not_differ_error_message() {
 
 
 # detects the type of the release store. sets RELEASE_STORE_TYPE either
-# to "local", "remote" or "s3" and also the following environment variables
+# to "local", "remote", "s3" or "docker" and also the following environment variables
 # depending on the detected release store type:
 #
 # AWS_SECRET_ACCESS_KEY (for s3)
 # AWS_SECRET_ACCESS_KEY (for s3)
 # AWS_BUCKET_NAME (for s3)
+# 
+# DOCKER_RUN_IMAGE (for docker)
 __detect_release_store_type() {
   if [[ "$RELEASE_STORE" =~ ^[sS]3://[^@]+@[^:]+:.+$ ]]; then
     local _s3location=${RELEASE_STORE/#[sS]3:\/\//}
@@ -1253,6 +1260,10 @@ __detect_release_store_type() {
 
   if [[ "$RELEASE_STORE" =~ ^[sS]3://[^@]+@[^:]+:.+$ ]] && [[ -n \"${AWS_ACCESS_KEY_ID}\" ]] && [[ -n \"${AWS_SECRET_ACCESS_KEY}\" ]] && [[ -n \"${AWS_BUCKET_NAME}\" ]]; then
     RELEASE_STORE_TYPE="s3"
+  elif [[ "$RELEASE_STORE" =~ ^docker://.+$ ]]; then
+    RELEASE_STORE_TYPE="docker"
+    DOCKER_RUN_IMAGE=${RELEASE_STORE/#docker:\/\//}
+    DOCKER_RELEASE_BASE_IMAGE=${DOCKER_RELEASE_BASE_IMAGE:-edeliver/release-base}
   elif [[ "$RELEASE_STORE" =~ ^[^@]+@[^:]+:.+$ ]]; then
     RELEASE_STORE_TYPE="remote"
   else

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -129,12 +129,12 @@ stop_build_container() {
 start_build_container() {
   status "Creating build container"
   info "Starting build container with image $DOCKER_BUILD_IMAGE"
-  local _target="${DELIVER_TO/\~//root}" # target must be absolute
+  CONTAINER_BUILD_DIR="${DELIVER_TO/\~//root}" # target must be absolute
   DOCKER_BUILD_DIR="$(pwd)/.docker-build"
   mkdir -p "$DOCKER_BUILD_DIR"
   DOCKER_BUILD_CONTAINER="$([ "$VERBOSE" != "true" ] && exec 2>/dev/null; \
     __docker run --detach \
-                 --mount type=bind,source="${DOCKER_BUILD_DIR}",target="$_target" \
+                 --mount type=bind,source="${DOCKER_BUILD_DIR}",target="$CONTAINER_BUILD_DIR" \
              "$DOCKER_BUILD_IMAGE" tail -f /dev/null)" \
     || error "Failed to start build container"
   info "Started container $DOCKER_BUILD_CONTAINER"
@@ -407,11 +407,24 @@ EOF
     status "Generating docker image with release"
     info "Creating image $DOCKER_RUN_IMAGE"
     info "Using base image $DOCKER_RELEASE_BASE_IMAGE"
-    info "Tagging as ${RELEASE_VERSION}-latest"
     if [[ -z "$(__docker images -q "$DOCKER_RELEASE_BASE_IMAGE")" ]]; then
       info "Pulling release base image $DOCKER_RELEASE_BASE_IMAGE"
       __docker pull "$DOCKER_RELEASE_BASE_IMAGE" || error "Failed to pull release base image $DOCKER_RELEASE_BASE_IMAGE"
     fi
+    local _release_container
+    info "Creating release container"
+    _release_container="$(__docker create "$DOCKER_RELEASE_BASE_IMAGE")" || error "Failed to create release container"
+    if [ -z "$RELEASE_DIR" ]; then
+      __detect_remote_release_dir || error "Failed to detect release dir"
+    fi
+    info "Copying release from build container into release container at /${APP}"
+    local _local_release_dir="${DOCKER_BUILD_DIR}${RELEASE_DIR#$CONTAINER_BUILD_DIR}"
+    [ -d "$_local_release_dir" ] || error "Local release dir '${_local_release_dir}' not found!"
+    __docker cp "$_local_release_dir" "${_release_container}:/${APP}" || error "Failed to copy release into release container"
+    [ "$VERBOSE" = "true" ] && __docker diff "$_release_container" || :
+    info "Commiting as ${RELEASE_VERSION}-latest"
+    __docker commit "$_release_container" "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-latest" \
+      || error "Failed to commit release container"
   else
     error_message "Cannot copy releases to store for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1293,7 +1293,7 @@ __detect_release_store_type() {
   elif [[ "$RELEASE_STORE" =~ ^docker://.+$ ]]; then
     RELEASE_STORE_TYPE="docker"
     DOCKER_RUN_IMAGE=${RELEASE_STORE/#docker:\/\//}
-    DOCKER_RELEASE_BASE_IMAGE=${DOCKER_RELEASE_BASE_IMAGE:-edeliver/release-base}
+    DOCKER_RELEASE_BASE_IMAGE=${DOCKER_RELEASE_BASE_IMAGE:-edeliver/release-base:1.0}
   elif [[ "$RELEASE_STORE" =~ ^[^@]+@[^:]+:.+$ ]]; then
     RELEASE_STORE_TYPE="remote"
   else

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -114,7 +114,7 @@ stop_build_container() {
   local status="$?"
   if [ "$status" = "0" ]; then
     status "Removing build container"
-    __docker kill $DOCKER_BUILD_CONTAINER
+    _=$( __docker kill $DOCKER_BUILD_CONTAINER ) 
     __docker rm $DOCKER_BUILD_CONTAINER
   else
     info "Stopping build container $DOCKER_BUILD_CONTAINER"

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -106,16 +106,6 @@ require_node_config() {
   fi
 }
 
-# runs docker and prints command output only if
-# edeliver runs with --verbose flag
-silent_docker() {
-  if [ "$VERBOSE" = "true" ]; then
-    docker $@
-  else
-    docker $@ >/dev/null
-  fi
-}
-
 # stops the build container whene deliver exits and a build
 # container was created because the BUILD_HOST is set to "docker".
 # if it exits normally the container is also removed, otherwise 
@@ -124,11 +114,11 @@ stop_build_container() {
   local status="$?"
   if [ "$status" = "0" ]; then
     status "Removing build container"
-    silent_docker kill $DOCKER_BUILD_CONTAINER
-    silent_docker rm $DOCKER_BUILD_CONTAINER
+    __docker kill $DOCKER_BUILD_CONTAINER
+    __docker rm $DOCKER_BUILD_CONTAINER
   else
-    echo "Stopping build container $DOCKER_BUILD_CONTAINER"
-    silent_docker kill $DOCKER_BUILD_CONTAINER
+    info "Stopping build container $DOCKER_BUILD_CONTAINER"
+    __docker kill $DOCKER_BUILD_CONTAINER
   fi
 }
 
@@ -143,9 +133,9 @@ start_build_container() {
   DOCKER_BUILD_DIR="$(pwd)/.docker-build"
   mkdir -p "$DOCKER_BUILD_DIR"
   DOCKER_BUILD_CONTAINER="$([ "$VERBOSE" != "true" ] && exec 2>/dev/null; \
-    docker run --detach \
-               --mount type=bind,source="${DOCKER_BUILD_DIR}",target="$_target" \
-           "$DOCKER_BUILD_IMAGE" tail -f /dev/null)" \
+    __docker run --detach \
+                 --mount type=bind,source="${DOCKER_BUILD_DIR}",target="$_target" \
+             "$DOCKER_BUILD_IMAGE" tail -f /dev/null)" \
     || error "Failed to start build container"
   info "Started container $DOCKER_BUILD_CONTAINER"
   if [ -n "$DOCKER_BUILD_CONTAINER" ]; then
@@ -389,7 +379,7 @@ EOF
     status "Copying $(basename $_release_file) to release store"
     __create_directory_in_release_store "/releases"
     if [ -n "$DOCKER_BUILD_CONTAINER" ]; then
-      __exec "docker cp ${DOCKER_BUILD_CONTAINER}:${_release_file} ${RELEASE_STORE}/releases/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz" \
+      __docker cp "${DOCKER_BUILD_CONTAINER}:${_release_file}" "${RELEASE_STORE}/releases/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz" \
         || error "Failed to copy release from container to release store"
     else
       __exec "scp -o ConnectTimeout=\"$SSH_TIMEOUT\"  -p $BUILD_USER@$BUILD_HOST:${_release_file} ${RELEASE_STORE}/releases/${APP}_${RELEASE_VERSION}${_release_revision}.${_release_type}.tar.gz" \

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -442,6 +442,16 @@ EOF
     error_message "Cannot copy releases to store for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi
 
+  if [ "$DOCKER_PUSH" = "true" ]; then
+    status "Pusing release image to registry"
+    info "Pushing ${_committed_image}"
+    __docker push "${_committed_image}" || error "Failed to push release image ${_committed_image}"
+    info "Pushing ${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_revision}"
+    __docker push "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_revision}" || error "Failed to push release image ${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_revision}"
+    info "Pushing ${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_branch}"
+    __docker push "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_branch}" || error "Failed to push release image ${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_branch}"
+  fi
+
 }
 
 # copies the release from the release store

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -418,6 +418,10 @@ EOF
     info "Creating image $DOCKER_RUN_IMAGE"
     info "Using base image $DOCKER_RELEASE_BASE_IMAGE"
     info "Tagging as ${RELEASE_VERSION}-latest"
+    if [[ -z "$(__docker images -q "$DOCKER_RELEASE_BASE_IMAGE")" ]]; then
+      info "Pulling release base image $DOCKER_RELEASE_BASE_IMAGE"
+      __docker pull "$DOCKER_RELEASE_BASE_IMAGE" || error "Failed to pull release base image $DOCKER_RELEASE_BASE_IMAGE"
+    fi
   else
     error_message "Cannot copy releases to store for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi

--- a/libexec/erlang
+++ b/libexec/erlang
@@ -417,14 +417,27 @@ EOF
     if [ -z "$RELEASE_DIR" ]; then
       __detect_remote_release_dir || error "Failed to detect release dir"
     fi
-    info "Copying release from build container into release container at /${APP}"
+    info "Copying built release into release container at /${APP}"
     local _local_release_dir="${DOCKER_BUILD_DIR}${RELEASE_DIR#$CONTAINER_BUILD_DIR}"
     [ -d "$_local_release_dir" ] || error "Local release dir '${_local_release_dir}' not found!"
     __docker cp "$_local_release_dir" "${_release_container}:/${APP}" || error "Failed to copy release into release container"
     [ "$VERBOSE" = "true" ] && __docker diff "$_release_container" || :
     info "Commiting as ${RELEASE_VERSION}-latest"
-    __docker commit "$_release_container" "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-latest" \
+    local _committed_image="${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-latest"
+    __docker commit "$_release_container" "$_committed_image" \
       || error "Failed to commit release container"
+
+    local _built_revision _build_branch
+    _built_revision="$([ -n "$DOCKER_BUILD_DIR" ] && cd "$DOCKER_BUILD_DIR" 2>/dev/null && git rev-parse --short HEAD 2>/dev/null)" && {
+      info "Tagging also as ${RELEASE_VERSION}-${_built_revision}"
+      __docker tag "$_committed_image" "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_revision}" \
+        || error "Failed to tag image with built revision"
+    } || hint_message "Failed to detect built revision"
+    _built_branch="$([ -n "$DOCKER_BUILD_DIR" ] && cd "$DOCKER_BUILD_DIR" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null)" && {
+      info "Tagging also as ${RELEASE_VERSION}-${_built_branch}"
+      __docker tag "$_committed_image" "${DOCKER_RUN_IMAGE}:${RELEASE_VERSION}-${_built_branch}" \
+        || error "Failed to tag image with branch name"
+    } || hint_message "Failed to detect built branch"
   else
     error_message "Cannot copy releases to store for store type ${RELEASE_STORE_TYPE}"; exit 2
   fi

--- a/libexec/erlang-init
+++ b/libexec/erlang-init
@@ -44,6 +44,7 @@ __help() {
   -D, --debug           Runs in shell debug mode, displays everything.
   -S, --skip-existing   Skip copying release archives if they exist already on the deploy hosts.
   -F, --force           Do not ask, just do, overwrite, delete or destroy everything
+      --push            Pushes the docker image after successful build if release store is a registry
       --clean-deploy    Delete the release, lib and erts-* directories before deploying the release
       --skip-git-clean  Don't build from a clean state for faster builds. See $GIT_CLEAN_PATHS env
       --skip-mix-clean  Skip the 'mix clean step' for faster builds. Use in addition to --skip-git-clean
@@ -405,6 +406,9 @@ do
     (--skip-relup-mod|--skip-relup-modification)
       SKIP_RELUP_MODIFICATIONS="true"
     ;;
+    (--push)
+      DOCKER_PUSH="true"
+      ;;
     (--runs-as-mix-task)
       RUNS_AS_MIX_TASK="true"
     ;;


### PR DESCRIPTION
if an image in a (private) docker registry is configured as `RELEASE_STORE`. The image is based on the `DOCKER_RELEASE_BASE_IMAGE` (which defaults to `edeliver/release-base`) and will be pushed with 3 tags: *release version* + *latest*, *release version* + *git sha* and *release version* + *branch*. The release can then be started like this:

```sh
docker start -ti edeliver/echo-server:1.0-latest -p 8080:8080 echo-server/bin/echo-server console
```
- [x] configure docker registry as release store
- [x] configure release image in release store url
- [x] configure release base image
- [x] build and tag the release container
- [x] push release container

Closes #121   