### PR TITLE
Use release version when linking vm args into container

### DIFF
--- a/libexec/erlang
+++ b/libexec/erlang
@@ -1102,7 +1102,8 @@ remote_extract_release_archive() {
     fi
     status "Extracting container start script into ${_archive_dir}"
     if [ -n "$LINK_VM_ARGS" ]; then
-      local _vm_args_dest="/${APP}/releases/${_release_version}/vm.args"
+      local _sem_ver="${_release_version%-*}" # remove trailing "-latest", "-<revision>" or "-<branch>"
+      local _vm_args_dest="/${APP}/releases/${_sem_ver}/vm.args"
       info "Configure mounting of vm args from $LINK_VM_ARGS to ${_vm_args_dest}"
       DOCKER_OPTS+=" --mount type=bind,source="${LINK_VM_ARGS}",target=${_vm_args_dest}"
     fi


### PR DESCRIPTION
instead of using docker tag as version. The tag contains an additional `-latest` or `-<git-sha>` suffix.

This won't work for release versions containg `-` characters. To fix this, the actual release version needs to added as
metadata to the docker image for instance.