### PR TITLE
Build mix project in docker on CI

### DIFF
--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -21,3 +21,14 @@ jobs:
     - name: Build Release TAR
       run: test/build-in-docker/build-mix.sh
   
+  build-distillery:
+
+    runs-on: ubuntu-latest
+
+    env:
+      TEST_LOCALLY_AT: /tmp/eco/distillery
+      ECO_PORT: 1883
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Release Container
+      run: test/build-in-docker/build-distillery.sh

--- a/.github/workflows/build-in-docker.yml
+++ b/.github/workflows/build-in-docker.yml
@@ -1,0 +1,23 @@
+name: Build TAR Release in Docker CI
+
+on: push
+
+env:
+  TERM: vt100 
+  APP: eco
+
+jobs:
+
+  build-mix:
+
+    runs-on: ubuntu-latest
+
+    env:
+      TEST_LOCALLY_AT: /tmp/eco/mix
+      ECO_PORT: 1883
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Release TAR
+      run: test/build-in-docker/build-mix.sh
+  

--- a/test/build-in-docker/build-distillery.sh
+++ b/test/build-in-docker/build-distillery.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Test building a docker release using the echo server from
+# https://github.com/xduludulu/erlang.eco
+set -e -o pipefail
+
+GIT_URL="${GIT_URL:-"https://github.com/xduludulu/erlang.eco"}"
+GIT_REF="16da11b"
+RELEASE_VERSION="0.1.0"
+APP="eco"
+BASE_DIR="$( cd "${0%/*}/../.." && pwd -P )"
+TESTS_DIR="$( cd "${0%/*}" && pwd -P )"
+DEFAULT_PROJECT_DIR="${BASE_DIR}/.test/echo-server-distillery"
+BRANCH_NAME="mix-distillery"
+EDELIVER="${BASE_DIR}/bin/edeliver"
+PROJECT_DIR="${PROJECT_DIR:-"$DEFAULT_PROJECT_DIR"}"
+
+_info() {
+  echo $@
+}
+
+_error() {
+  echo "" >&2
+  echo $@ >&2
+  echo "" >&2
+  exit 1
+}
+
+if [ ! -x "$EDELIVER" ]; then
+  _error "edeliver executable not found at '$EDELIVER'!"
+fi
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  _info "Creating project dir '$PROJECT_DIR'"
+  mkdir -p "$PROJECT_DIR"
+fi
+
+cd "$PROJECT_DIR"
+_info "Cloning $GIT_URL"
+git clone "$GIT_URL" .
+_info "Checking out $GIT_REF"
+git checkout "$GIT_REF"
+
+_info "Applying distillery config…"
+# copy mix.exs and remove rebar.config
+cp "${TESTS_DIR}/../configs/mix-distillery.exs" "${PROJECT_DIR}/mix.exs"
+git rm "${PROJECT_DIR}/rebar.config"
+# create distillery release config
+mkdir -p "${PROJECT_DIR}/rel"
+cp "${TESTS_DIR}/../configs/distillery-rel-config.exs" "${PROJECT_DIR}/rel/config.exs"
+cp "${TESTS_DIR}/../configs/distillery-vm.args" "${PROJECT_DIR}/rel/vm.args"
+# create app config
+mkdir -p "${PROJECT_DIR}/config"
+cp "${TESTS_DIR}/../configs/distillery-app-config.exs" "${PROJECT_DIR}/config/config.exs"
+
+# commit new configs
+git add "${PROJECT_DIR}/mix.exs" "${PROJECT_DIR}/rel" "${PROJECT_DIR}/rel/vm.args"
+git add "${PROJECT_DIR}/config/config.exs" "${PROJECT_DIR}/rel/config.exs"
+git config user.email "edeliver-test@github.com"
+git config user.name "Edeliver Test"
+git commit -m "Add distillery mix file"
+git branch -d "$BRANCH_NAME" 2>/dev/null || :
+git checkout -b "$BRANCH_NAME"
+
+GIT_REF="$(git rev-parse --short HEAD)"
+
+_info "Building release…"
+BUILD_HOST="docker" \
+APP="$APP" \
+BUILD_AT="/echo-server" \
+BUILD_USER="root" \
+MIX_ENV="prod" \
+DOCKER_BUILD_IMAGE="elixir:1.11.4" \
+"$EDELIVER" build release --verbose --branch="$BRANCH_NAME"
+
+_info ""
+_info "Checking whether TAR was built successfully…"
+ls -al "${PROJECT_DIR}/.deliver/releases/${APP}_${RELEASE_VERSION}.release.tar.gz"
+if [ -f "${PROJECT_DIR}/.deliver/releases/${APP}_${RELEASE_VERSION}.release.tar.gz" ]; then
+  _info "TAR was built successfully"
+  echo "release_version=${RELEASE_VERSION}-${GIT_REF}" >> $GITHUB_ENV
+else
+  _error "Building TAR failed!"
+fi

--- a/test/build-in-docker/build-mix.sh
+++ b/test/build-in-docker/build-mix.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Test building a tar release using the echo server from
+# https://github.com/xduludulu/erlang.eco
+set -e -o pipefail
+
+GIT_URL="${GIT_URL:-"https://github.com/xduludulu/erlang.eco"}"
+GIT_REF="16da11b"
+RELEASE_VERSION="0.1.0"
+APP="eco"
+BASE_DIR="$( cd "${0%/*}/../.." && pwd -P )"
+TESTS_DIR="$( cd "${0%/*}" && pwd -P )"
+DEFAULT_PROJECT_DIR="${BASE_DIR}/.test/echo-server-mix"
+BRANCH_NAME="mix-release"
+EDELIVER="${BASE_DIR}/bin/edeliver"
+PROJECT_DIR="${PROJECT_DIR:-"$DEFAULT_PROJECT_DIR"}"
+  
+_info() {
+  echo $@
+}
+
+_error() {
+  echo "" >&2
+  echo $@ >&2
+  echo "" >&2
+  exit 1
+}
+
+if [ ! -x "$EDELIVER" ]; then
+  _error "edeliver executable not found at '$EDELIVER'!"
+fi
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  _info "Creating project dir '$PROJECT_DIR'"
+  mkdir -p "$PROJECT_DIR"
+fi
+
+cd "$PROJECT_DIR"
+_info "Cloning $GIT_URL"
+git clone "$GIT_URL" .
+_info "Checking out $GIT_REF"
+git checkout "$GIT_REF"
+
+_info "Applying distillery config…"
+# copy mix.exs and remove rebar.config
+cp "${TESTS_DIR}/../configs/mix-elixir.exs" "${PROJECT_DIR}/mix.exs"
+git rm "${PROJECT_DIR}/rebar.config"
+
+# commit new configs
+git add "${PROJECT_DIR}/mix.exs"
+git config user.email "edeliver-test@github.com"
+git config user.name "Edeliver Test"
+git commit -m "Add distillery mix file"
+git branch -d "$BRANCH_NAME" 2>/dev/null || :
+git checkout -b "$BRANCH_NAME"
+
+GIT_REF="$(git rev-parse --short HEAD)"
+
+_info "Building release…"
+BUILD_HOST="docker" \
+APP="$APP" \
+BUILD_AT="/echo-server" \
+BUILD_USER="root" \
+MIX_ENV="prod" \
+USING_DISTILLERY="false" \
+DOCKER_BUILD_IMAGE="elixir:1.11.4" \
+"$EDELIVER" build release --verbose --branch="$BRANCH_NAME"
+
+_info ""
+_info "Checking whether TAR was built successfully…"
+ls -al "${PROJECT_DIR}/.deliver/releases/${APP}_${RELEASE_VERSION}.release.tar.gz"
+if [ -f "${PROJECT_DIR}/.deliver/releases/${APP}_${RELEASE_VERSION}.release.tar.gz" ]; then
+  _info "TAR was built successfully"
+  echo "release_version=${RELEASE_VERSION}-${GIT_REF}" >> $GITHUB_ENV
+else
+  _error "Building TAR failed!"
+fi


### PR DESCRIPTION
Add GitHub action to build a mix project on CI either with the builtin release tool or with distillery.