### PR TITLE
fix: add docker folder to mix package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Edeliver.Mixfile do
       files: [
         "bin",
         "CHANGELOG.md",
+        "docker",
         "lib",
         "libexec",
         "mix.exs",


### PR DESCRIPTION
Script was failing to copy over `/docker/start_container` as it doesn't exist in the package from hex.

```
-----> Uploading archive of release 0.1.091d08c2-lorenzoedeliver-latest from docker release store
-----> Extracting container start script into /home/docker/apps/project/bin
cat: /Users/lorenzo/projects/project/deps/edeliver/docker/start_container: No such file or directory
Copied edeliver default script
Using edeliver default script.\nPlease consider to add your own version at /project/bin/start_container.\n

DEPLOYED RELEASE TO PRODUCTION!
```